### PR TITLE
Add context menu with option to jump to Caller/Callee

### DIFF
--- a/src/flamegraph.cpp
+++ b/src/flamegraph.cpp
@@ -44,6 +44,7 @@
 #include <QCheckBox>
 #include <QDoubleSpinBox>
 #include <QCursor>
+#include <QMenu>
 
 #include <ThreadWeaver/ThreadWeaver>
 #include <KLocalizedString>
@@ -447,6 +448,19 @@ bool FlameGraph::eventFilter(QObject* object, QEvent* event)
         updateTooltip();
     } else if (event->type() == QEvent::Hide) {
         setData(nullptr);
+    } else if (event->type() == QEvent::ContextMenu) {
+        QContextMenuEvent *contextEvent = static_cast<QContextMenuEvent*>(event);
+        auto item = static_cast<FrameGraphicsItem*>(m_view->itemAt(m_view->mapFromGlobal(contextEvent->globalPos())));
+        if (!item) {
+            return ret;
+        }
+
+        QMenu contextMenu;
+        auto *viewCallerCallee = contextMenu.addAction(tr("View Caller/Callee"));
+        QAction *action = contextMenu.exec(QCursor::pos());
+        if (action == viewCallerCallee) {
+            emit jumpToCallerCallee(item->symbol());
+        }
     }
     return ret;
 }

--- a/src/flamegraph.h
+++ b/src/flamegraph.h
@@ -56,6 +56,9 @@ protected:
 private slots:
     void setData(FrameGraphicsItem* rootItem);
 
+signals:
+    void jumpToCallerCallee(const Data::Symbol& symbol);
+
 private:
     void setTooltipItem(const FrameGraphicsItem* item);
     void updateTooltip();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -35,7 +35,14 @@ namespace Ui {
 class MainWindow;
 }
 
+namespace Data {
+struct Symbol;
+}
+
 class PerfParser;
+class CallerCalleeModel;
+class QSortFilterProxyModel;
+class QTreeView;
 
 class MainWindow : public QMainWindow
 {
@@ -62,9 +69,16 @@ public slots:
 private slots:
     void on_openFileButton_clicked();
 
+    void customContextMenu(const QPoint &point, QTreeView* view, int symbolRole);
+    void onBottomUpContextMenu(const QPoint &pos);
+    void onTopDownContextMenu(const QPoint &pos);
+    void jumpToCallerCallee(const Data::Symbol &symbol);
+
 private:
     QScopedPointer<Ui::MainWindow> ui;
     PerfParser* m_parser;
+    CallerCalleeModel* m_callerCalleeCostModel;
+    QSortFilterProxyModel* m_callerCalleeProxy;
     QString m_sysroot;
     QString m_kallsyms;
     QString m_debugPaths;

--- a/src/models/callercalleemodel.cpp
+++ b/src/models/callercalleemodel.cpp
@@ -114,6 +114,16 @@ QVariant CallerCalleeModel::cell(Columns column, int role, const Data::Symbol& s
     return {};
 }
 
+QModelIndex CallerCalleeModel::indexForSymbol(const Data::Symbol& symbol)
+{
+    auto it = m_rows.find(symbol);
+    if (it == m_rows.end()) {
+        return {};
+    }
+    const int row = std::distance(m_rows.begin(), it);
+    return createIndex(row, 0);
+}
+
 CallerModel::CallerModel(QObject* parent)
     : SymbolCostModelImpl(parent)
 {

--- a/src/models/callercalleemodel.h
+++ b/src/models/callercalleemodel.h
@@ -64,6 +64,7 @@ public:
     static QVariant headerCell(Columns column, int role);
     static QVariant cell(Columns column, int role, const Data::Symbol& symbol,
                          const Data::CallerCalleeEntry& entry);
+    QModelIndex indexForSymbol(const Data::Symbol& symbol);
 };
 
 template<typename ModelImpl>

--- a/src/models/hashmodel.h
+++ b/src/models/hashmodel.h
@@ -104,7 +104,9 @@ public:
         return index(row, column);
     }
 
-private:
+protected:
     Rows m_rows;
+
+private:
     quint64 m_sampleCount = 0;
 };

--- a/src/models/treemodel.h
+++ b/src/models/treemodel.h
@@ -41,7 +41,8 @@ public:
     enum Roles {
         SortRole = Qt::UserRole,
         TotalCostRole,
-        FilterRole
+        FilterRole,
+        SymbolRole
     };
 };
 
@@ -143,6 +144,8 @@ public:
             return ModelImpl::displayData(item, static_cast<typename ModelImpl::Columns>(index.column()));
         } else if (role == TotalCostRole) {
             return m_sampleCount;
+        } else if (role == SymbolRole) {
+            return QVariant::fromValue(item->symbol);
         }
 
         // TODO: tooltips


### PR DESCRIPTION
Add context menu with option to jump to Caller/Callee tab from Bottom-Up, Top-Down, and Flame-Graph.

Fixes #33