### PR TITLE
Add an Open in Editor feature

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -74,6 +74,12 @@ private slots:
     void onTopDownContextMenu(const QPoint &pos);
     void jumpToCallerCallee(const Data::Symbol &symbol);
 
+    void setupCodeNavigationMenu();
+    void navigateToCode(const QString &url, int lineNumber, int columnNumber);
+    void setCodeNavigationIDE(QAction *action);
+
+    void onSourceMapContextMenu(const QPoint &pos);
+
 private:
     QScopedPointer<Ui::MainWindow> ui;
     PerfParser* m_parser;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -239,7 +239,7 @@
         <item>
          <widget class="QTabWidget" name="resultsTabWidget">
           <property name="currentIndex">
-           <number>0</number>
+           <number>4</number>
           </property>
           <property name="documentMode">
            <bool>true</bool>
@@ -617,8 +617,14 @@
      <string>&amp;File</string>
     </property>
    </widget>
+   <widget class="QMenu" name="settingsMenu">
+    <property name="title">
+     <string>Settings</string>
+    </property>
+   </widget>
    <addaction name="fileMenu"/>
    <addaction name="helpMenu"/>
+   <addaction name="settingsMenu"/>
   </widget>
   <action name="actionAbout_Hotspot">
    <property name="text">


### PR DESCRIPTION
Add an Open in Editor feature to allow the user to setup a default editor and open a source file from the Location section of the Caller/Callee tab in that editor.

This commit introduces the Open in Editor from GammaRay and adapts it
for usage in hotspot.

Fixes #10