### PR TITLE
Perf: Reserve memory for QSet

### DIFF
--- a/src/parsers/perf/perfparser.cpp
+++ b/src/parsers/perf/perfparser.cpp
@@ -842,6 +842,7 @@ struct PerfParserPrivate
         bottomUpResult.costs.incrementTotal(sample.attributeId);
         auto parent = &bottomUpResult.root;
         QSet<Data::Symbol> recursionGuard;
+        recursionGuard.reserve(64);
         for (auto id : sample.frames) {
             parent = addFrame(parent, id, &recursionGuard, sample.attributeId);
         }


### PR DESCRIPTION
Summary:
32 seems to be a good candidate here, deduced from taking the highest
number from a 500 MB perf.data snapshot.