### PR TITLE
Add missing include

### DIFF
--- a/src/parsers/perf/perfparser.h
+++ b/src/parsers/perf/perfparser.h
@@ -29,6 +29,7 @@
 
 #include <QObject>
 #include <memory>
+#include <functional>
 
 #include <models/data.h>
 


### PR DESCRIPTION
Include `<functional>` as it's needed for std::function.