### PR TITLE
Add extra-cmake-modules to Debian build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ As of now, you will need the following dependencies to build this project:
 ### On Debian/Ubuntu
 
 ```
-apt-get install libkf5threadweaver-dev libkf5i18n-dev libkf5configwidgets-dev libkf5coreaddons-dev libkf5itemviews-dev libkf5itemmodels-dev libelf-dev libdw-dev cmake
+apt-get install libkf5threadweaver-dev libkf5i18n-dev libkf5configwidgets-dev libkf5coreaddons-dev libkf5itemviews-dev libkf5itemmodels-dev libelf-dev libdw-dev cmake extra-cmake-modules
 ```
 
 ## Building


### PR DESCRIPTION
Add the package extra-cmake-modules to the Debian install call in the build
instructions. They are mentioned in the dependencies, but have not been
included in the apt-get call.

This was a blocker when compiling the application based on the instructions.