### PR TITLE
TravisCI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+
+services:
+  - docker
+
+install:
+  - docker build -t hotspot .
+
+script:
+  - docker run -v $TRAVIS_BUILD_DIR:/hotspot hotspot /bin/sh -c "cd hotspot && mkdir build-hotspot && cd build-hotspot && cmake .. && make"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:17.04
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gettext \
+    libkf5threadweaver-dev \
+    libkf5i18n-dev \
+    libkf5configwidgets-dev \
+    libkf5coreaddons-dev \
+    libkf5itemviews-dev \
+    libkf5itemmodels-dev \
+    libelf-dev \
+    libdw-dev \
+    cmake \
+    extra-cmake-modules


### PR DESCRIPTION
I created a simple configuration file for Travis CI if you are interested.

Sadly the latest Ubuntu environment is 16.04 on Travis CI and I couldn't make the build work on it, so I had to use docker to have the latest Ubuntu. The downside is that I can't install the necessary perf package there, so the tst_perfparser test is not working.

This is unfortunate, but I think the automatic build is still helpful.