### PR TITLE
Fedora requires additional dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: require
 dist: trusty
 
 before_install:
-  - sudo add-apt-repository ppa:beineri/opt-qt59-trusty -y
+  - sudo add-apt-repository ppa:beineri/opt-qt591-trusty -y
   - sudo apt-get update -qq
     
 install: 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ apt-get install libkf5threadweaver-dev libkf5i18n-dev libkf5configwidgets-dev \
 
 ### On Fedora
 ```
-dnf install cmake gcc gcc-c++ qt5 qt5-devel extra-cmake-modules elfutils-devel \
-    kf5-threadweaver-devel kf5-ki18n-devel kf5-kconfigwidgets-devel \
-    kf5-kitemviews-devel kf5-kitemmodels-devel kf5-kio-devel kf5-solid-devel
+dnf install cmake gcc glibc-static gcc-c++ libstdc++-static qt5 qt5-devel \
+    extra-cmake-modules elfutils-devel f5-threadweaver-devel kf5-ki18n-devel \
+    kf5-kconfigwidgets-devel kf5-kitemviews-devel kf5-kitemmodels-devel \
+    kf5-kio-devel kf5-solid-devel kf5-kwindowsystem
 ```
 
 ### Arch Linux


### PR DESCRIPTION
To link bin/hotspot package 'kf5-kwindowsystem' is required.
To link cpp-minimal-static, static versions of the respective C and C++ std-libs are required.

This is true for Fedora 26. Did not test on 25.