### PR TITLE
Fix: Typo in the installation on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ apt-get install libkf5threadweaver-dev libkf5i18n-dev libkf5configwidgets-dev \
 ### On Fedora
 ```
 dnf install cmake gcc glibc-static gcc-c++ libstdc++-static qt5 qt5-devel \
-    extra-cmake-modules elfutils-devel f5-threadweaver-devel kf5-ki18n-devel \
+    extra-cmake-modules elfutils-devel kf5-threadweaver-devel kf5-ki18n-devel \
     kf5-kconfigwidgets-devel kf5-kitemviews-devel kf5-kitemmodels-devel \
     kf5-kio-devel kf5-solid-devel kf5-kwindowsystem
 ```


### PR DESCRIPTION
I try to install hotspot on Fedora and find the typo in some package.