### PR TITLE
Add include directories for libelf.h

### DIFF
--- a/3rdparty/perfparser.cmake
+++ b/3rdparty/perfparser.cmake
@@ -1,5 +1,5 @@
 include_directories(
-    ${LIBELF_INCLUDE_DIR}
+    ${LIBELF_INCLUDE_DIRS}
     ${LIBDW_INCLUDE_DIR}/elfutils
     ${LIBDWARF_INCLUDE_DIRS}
     perfparser/app


### PR DESCRIPTION
This makes sure a custom libelf.h is picked instead of the system
libelf.h when available.