### PR TITLE
README: Correct Arch Linux installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,11 +158,7 @@ If you need help building this project for your platform, [contact us for help](
 
 ### ArchLinux
 
-Install hotspot via AUR (https://aur.archlinux.org/packages/hotspot)
-
-```
-pacman -S hotspot
-```
+hotspot is available in AUR (https://aur.archlinux.org/packages/hotspot).
 
 ### For any Linux distro: AppImage
 


### PR DESCRIPTION
hotspot is available only in AUR, so we can't use pacman.

That's okay to omit how to install packages from AUR because most Arch
Linux users know how to do that, they only need name of the package.