### PR TITLE
Add back/forward history buttons to flamegraph view

### DIFF
--- a/src/flamegraph.h
+++ b/src/flamegraph.h
@@ -38,6 +38,7 @@ class QGraphicsView;
 class QComboBox;
 class QLabel;
 class QLineEdit;
+class QPushButton;
 
 class FrameGraphicsItem;
 
@@ -83,6 +84,8 @@ private:
     QAction* m_forwardAction = nullptr;
     QAction* m_backAction = nullptr;
     QAction* m_resetAction = nullptr;
+    QPushButton* m_backButton = nullptr;
+    QPushButton* m_forwardButton = nullptr;
     const FrameGraphicsItem* m_tooltipItem = nullptr;
     FrameGraphicsItem* m_rootItem = nullptr;
     QVector<FrameGraphicsItem*> m_selectionHistory;


### PR DESCRIPTION
Hey there,

When I first opened up flamegraph view I did not realise that there's symbol history until I read it's source. I imagine that having UI buttons might be helpful for new users.

![hotspot_buttons](https://user-images.githubusercontent.com/5294515/45585573-d9bf9380-b8e6-11e8-988f-9ab843df1dd0.png)
