### PR TITLE
Add support for prettifying symbols in cpp-parallel

### DIFF
--- a/src/models/data.cpp
+++ b/src/models/data.cpp
@@ -194,6 +194,15 @@ QString prettifySymbol(const QStringRef& str)
     const auto oneParameterTemplates = {"vector<",       "set<",      "deque<",         "list<",
                                         "forward_list<", "multiset<", "unordered_set<", "unordered_multiset<"};
     const auto twoParametersTemplates = {"map<", "multimap<", "unordered_map<", "unordered_multimap<"};
+    const auto hideParametersTemplates = {
+        // Generic
+        "allocator<", "call_once<",
+        // libc++ internal
+        "__thread_proxy<",
+        // libstdc++ internal
+        "thread::_Invoker<", "_Function_handler<", "__future_base::_Task_setter<",
+        "__invoke_result<",  "__invoke<", "__invoke_impl<",
+        "unique_ptr<std::__future_base::_Result_base, "};
 
     // Translate basic_string<(char|wchar_t|T), ...> to (string|wstring|basic_string<T>)
     if ((end = startsWith(symbol, {"basic_string<"})) != -1) {
@@ -255,8 +264,8 @@ QString prettifySymbol(const QStringRef& str)
             symbol = symbol.mid(end);
         }
     }
-    // Translates allocator<T> to allocator<...>
-    else if ((end = startsWith(symbol, {"allocator<"})) != -1) {
+    // Translates (allocator|etc.)<T> to (allocator|etc.)<...>
+    else if ((end = startsWith(symbol, hideParametersTemplates)) != -1) {
         const int gt = findSameDepth(symbol, 0, QLatin1Char('>'), true);
         if (gt != -1) {
             result += symbol.left(end);

--- a/tests/modeltests/tst_models.cpp
+++ b/tests/modeltests/tst_models.cpp
@@ -470,6 +470,24 @@ private slots:
                " char const (&) [1], char const (&) [1],"
                " std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&"
                "> >, bool ()>::operator()()";
+        QTest::newRow("std::call_once")
+            << "void std::call_once<...>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<"
+               "std::unique_ptr<std::__future_base::_Result_base, ...> ()>*, bool*"
+               "), std::__future_base::_State_baseV2*&&, std::function<"
+               "std::unique_ptr<std::__future_base::_Result_base, ...> ()>*&&, bool*&&)"
+            << "void std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<"
+               "std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*"
+               "), std::__future_base::_State_baseV2*, std::function<"
+               "std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*"
+               ">(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<"
+               "std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*"
+               "), std::__future_base::_State_baseV2*&&, std::function<"
+               "std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&)";
+        QTest::newRow("std::thread::_Invoker")
+            << "std::thread::_Invoker<...>::operator()"
+            << "std::thread::_Invoker<std::tuple<std::__future_base::_Async_state_impl<"
+               "std::thread::_Invoker<std::tuple<double (*)()> >, double>"
+               "::_Async_state_impl(std::thread::_Invoker<std::tuple<double (*)()> >&&)::{lambda()#1}> >::operator()";
     }
 
     void testPrettySymbol()


### PR DESCRIPTION
This is done by hiding parts (i.e. replacing with ...) of the internal templates used by primarily libstdc++.

It was requested in #195 that the symbols in cpp-parallel be prettified as well. This is one suggestion that hides big parts of the internal templates which doesn't add much useful information.

Let me know what you think.