### PR TITLE
Reset filter and zoom stack when reloading file

### DIFF
--- a/src/models/filterandzoomstack.cpp
+++ b/src/models/filterandzoomstack.cpp
@@ -90,6 +90,12 @@ FilterAndZoomStack::Actions FilterAndZoomStack::actions() const
     return m_actions;
 }
 
+void FilterAndZoomStack::clear()
+{
+    m_filterStack.clear();
+    m_zoomStack.clear();
+}
+
 void FilterAndZoomStack::filterInByTime(const Data::TimeRange &time)
 {
     zoomIn(time);

--- a/src/models/filterandzoomstack.h
+++ b/src/models/filterandzoomstack.h
@@ -56,6 +56,8 @@ public:
 
     Actions actions() const;
 
+    void clear();
+
 public slots:
     void filterInByTime(const Data::TimeRange &time);
     void filterInByProcess(qint32 processId);

--- a/src/resultspage.cpp
+++ b/src/resultspage.cpp
@@ -211,6 +211,8 @@ void ResultsPage::clear()
     m_resultsTopDownPage->clear();
     m_resultsCallerCalleePage->clear();
     m_resultsFlameGraphPage->clear();
+
+    m_filterAndZoomStack->clear();
 }
 
 QMenu* ResultsPage::filterMenu() const


### PR DESCRIPTION
Otherwise the timeline may end up in a state where it looks like it's empty and
requires a manual reset.