### PR TITLE
Remove deprecated calls to QTreeView::sortByColumn

### DIFF
--- a/src/resultscallercalleepage.cpp
+++ b/src/resultscallercalleepage.cpp
@@ -51,7 +51,7 @@ Model* setupModelAndProxyForView(QTreeView* view)
     auto proxy = new QSortFilterProxyModel(model);
     proxy->setSourceModel(model);
     proxy->setSortRole(Model::SortRole);
-    view->sortByColumn(Model::InitialSortColumn);
+    view->sortByColumn(Model::InitialSortColumn, Qt::DescendingOrder);
     view->setModel(proxy);
     ResultsUtil::stretchFirstColumn(view);
     ResultsUtil::setupCostDelegate(model, view);
@@ -94,7 +94,7 @@ ResultsCallerCalleePage::ResultsCallerCalleePage(FilterAndZoomStack* filterStack
         ResultsUtil::hideEmptyColumns(data.selfCosts, ui->callerCalleeTableView,
                                       CallerCalleeModel::NUM_BASE_COLUMNS + data.inclusiveCosts.numTypes());
         auto view = ui->callerCalleeTableView;
-        view->sortByColumn(CallerCalleeModel::InitialSortColumn);
+        view->sortByColumn(CallerCalleeModel::InitialSortColumn, view->header()->sortIndicatorOrder());
         view->setCurrentIndex(view->model()->index(0, 0, {}));
         ResultsUtil::hideEmptyColumns(data.inclusiveCosts, ui->callersView, CallerModel::NUM_BASE_COLUMNS);
         ResultsUtil::hideEmptyColumns(data.inclusiveCosts, ui->calleesView, CalleeModel::NUM_BASE_COLUMNS);

--- a/src/resultsutil.cpp
+++ b/src/resultsutil.cpp
@@ -59,7 +59,7 @@ void setupTreeView(QTreeView* view, KFilterProxySearchLine* filter, QAbstractIte
 
     filter->setProxy(proxy);
 
-    view->sortByColumn(initialSortColumn);
+    view->sortByColumn(initialSortColumn, Qt::DescendingOrder);
     view->setModel(proxy);
     stretchFirstColumn(view);
 }


### PR DESCRIPTION
On the two cases that it's setup calls, use Qt::DescendingOrder

In the one that is called from a "has data" signal, then reuse
the views header sortIndicatorOrder so to not override what the user may
had chosen