### PR TITLE
Catskul/fix allow compile qt 5 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
     
 install: 
   - sudo apt-get -y install qt510base qt510svg qt510x11extras
+  - sudo apt-get -y install mesa-common-dev libglu1-mesa-dev
   - source /opt/qt*/bin/qt*-env.sh
   - git clone git://anongit.kde.org/extra-cmake-modules
   - cd extra-cmake-modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: cpp
 compiler: gcc
 sudo: require
-dist: trusty
+dist: xenial
 
 before_install:
-  - sudo add-apt-repository ppa:beineri/opt-qt-5.10.1-trusty -y
+  - sudo add-apt-repository ppa:beineri/opt-qt-5.10.1-xenial -y
   - sudo apt-get update -qq
     
 install: 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ set(HOTSPOT_VERSION_STRING "${hotspot_VERSION}")
 
 include(FeatureSummary)
 
-find_package(Qt5 5.10 COMPONENTS Core Widgets Network Test Svg REQUIRED)
+find_package(Qt5 5.9 COMPONENTS Core Widgets Network Test Svg REQUIRED)
 find_package(LibElf REQUIRED)
 find_package(Elfutils REQUIRED) # TODO: make optional, use internal copy
 find_package(ECM 1.0.0 NO_MODULE REQUIRED)

--- a/src/models/processfiltermodel.cpp
+++ b/src/models/processfiltermodel.cpp
@@ -36,7 +36,9 @@
 ProcessFilterModel::ProcessFilterModel(QObject* parent)
     : QSortFilterProxyModel(parent)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     setRecursiveFilteringEnabled(true);
+#endif
 
     m_currentProcId = QString::number(qApp->applicationPid());
     m_currentUser = KUser().loginName();

--- a/src/resultspage.cpp
+++ b/src/resultspage.cpp
@@ -43,6 +43,8 @@
 
 #include <KLocalizedString>
 
+#include <chrono>
+
 #include <QDebug>
 #include <QEvent>
 #include <QMenu>
@@ -50,7 +52,6 @@
 #include <QSortFilterProxyModel>
 #include <QTimer>
 
-#include <chrono>
 
 static const int SUMMARY_TABINDEX = 0;
 

--- a/src/resultspage.cpp
+++ b/src/resultspage.cpp
@@ -50,6 +50,8 @@
 #include <QSortFilterProxyModel>
 #include <QTimer>
 
+#include <chrono>
+
 static const int SUMMARY_TABINDEX = 0;
 
 ResultsPage::ResultsPage(PerfParser* parser, QWidget* parent)

--- a/src/resultspage.cpp
+++ b/src/resultspage.cpp
@@ -97,7 +97,10 @@ ResultsPage::ResultsPage(PerfParser* parser, QWidget* parent)
 
     auto* eventModel = new EventModel(this);
     auto* timeLineProxy = new QSortFilterProxyModel(this);
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     timeLineProxy->setRecursiveFilteringEnabled(true);
+#endif
     timeLineProxy->setSourceModel(eventModel);
     timeLineProxy->setSortRole(EventModel::SortRole);
     timeLineProxy->setFilterKeyColumn(EventModel::ThreadColumn);

--- a/src/resultsutil.cpp
+++ b/src/resultsutil.cpp
@@ -73,7 +73,10 @@ void setupTreeView(QTreeView* view, QLineEdit* filter, QAbstractItemModel* model
                    int sortRole, int filterRole)
 {
     auto proxy = new QSortFilterProxyModel(view);
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     proxy->setRecursiveFilteringEnabled(true);
+#endif
     proxy->setSortRole(sortRole);
     proxy->setFilterRole(filterRole);
     proxy->setSourceModel(model);

--- a/tests/modeltests/tst_models.cpp
+++ b/tests/modeltests/tst_models.cpp
@@ -277,11 +277,11 @@ private slots:
             QCOMPARE(maxTime, endTime);
             const auto minTime = idx.data(EventModel::MinTimeRole).value<quint64>();
             QCOMPARE(minTime, quint64(0));
-            const auto numProcesses = idx.data(EventModel::NumProcessesRole).value<uint>();
+            const auto numProcesses = idx.data(EventModel::NumProcessesRole).value<int>();
             QCOMPARE(numProcesses, processes);
-            const auto numThreads = idx.data(EventModel::NumThreadsRole).value<uint>();
+            const auto numThreads = idx.data(EventModel::NumThreadsRole).value<int>();
             QCOMPARE(numThreads, events.threads.size());
-            const auto numCpus = idx.data(EventModel::NumCpusRole).value<uint>();
+            const auto numCpus = idx.data(EventModel::NumCpusRole).value<int>();
             QCOMPARE(numCpus, nonEmptyCpus);
             const auto maxCost = idx.data(EventModel::MaxCostRole).value<quint64>();
             QCOMPARE(maxCost, quint64(10));
@@ -302,7 +302,7 @@ private slots:
                 // let's only look at the first process
                 parent = model.index(0, EventModel::ThreadColumn, parent);
                 verifyCommonData(parent);
-                QCOMPARE(parent.data().toString(), "foobar (#1234)");
+                QCOMPARE(parent.data().toString(), QString("foobar (#1234)"));
                 numRows = model.rowCount(parent);
                 QCOMPARE(numRows, 2);
             }


### PR DESCRIPTION
Allow compile with Qt 5.9:

 * Adds in preprocessor ifs around `RecursiveSort` to allow compilation with 18.04s default qt install qt-5.9. (Might be possible to drop down to qt 5.7 (debian 9s default)
 * appeases `qCompare` link error related to inexact type comparison
 * updates `perfparser` pointer to version which also resolves qCompare issues there
 * requires merge of https://github.com/KDAB/perfparser/pull/8 first