### PR TITLE
Keep current reults page when reloading perf data

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -87,6 +87,8 @@ signals:
     void archChanged(const QString& arch);
 
 private:
+    void clear(bool isReload);
+    void openFile(const QString& path, bool isReload);
     void closeEvent(QCloseEvent* event) override;
     void setupCodeNavigationMenu();
     void setupPathSettingsMenu();


### PR DESCRIPTION
It's nice to stay at e.g the flame graph after pressing F5 to get the latest data.