### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ apt-get update
 apt-get install libkf5threadweaver-dev libkf5i18n-dev libkf5configwidgets-dev \
     libkf5coreaddons-dev libkf5itemviews-dev libkf5itemmodels-dev libkf5kio-dev \
     libkf5solid-dev libkf5windowsystem-dev libelf-dev libdw-dev cmake \
-    extra-cmake-modules gettext
+    extra-cmake-modules gettext libqt5svg5-dev
 ```
 
 ### On Fedora


### PR DESCRIPTION
Cmake failed on my system (running Ubuntu 20.04) with the "apt-get install ..." command in the readme. The Cmake error was 
```
CMake Error at /usr/lib/x86_64-linux-gnu/cmake/Qt5/Qt5Config.cmake:28 (find_package):
  Could not find a package configuration file provided by "Qt5Svg" with any
  of the following names:

    Qt5SvgConfig.cmake
    qt5svg-config.cmake

  Add the installation prefix of "Qt5Svg" to CMAKE_PREFIX_PATH or set
  "Qt5Svg_DIR" to a directory containing one of the above files.  If "Qt5Svg"
  provides a separate development package or SDK, be sure it has been
  installed.
Call Stack (most recent call first):
  CMakeLists.txt:49 (find_package)
```
 To fix this, I had to also install libqt5svg5-dev. I added "libqt5svg5-dev" to the "apt-get install" command.