### PR TITLE
Run perf record --help with LANG=C

### DIFF
--- a/src/perfrecord.cpp
+++ b/src/perfrecord.cpp
@@ -345,6 +345,9 @@ static QByteArray perfRecordHelp()
 {
     static const QByteArray recordHelp = []() {
         QProcess testProcess;
+        QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+        env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+        testProcess.setProcessEnvironment(env);
         testProcess.start(QStringLiteral("perf"), {QStringLiteral("record"), QStringLiteral("--help")});
         testProcess.waitForFinished(1000);
         return testProcess.readAllStandardOutput();


### PR DESCRIPTION
This way we make sure we get the expected output.

---

It doesn't seem to like the locale I have on my system:

```
$ perf record --help | cat
man: can't set the locale; make sure $LC_* and $LANG are correct
col: failed on line 19: Invalid or incomplete multibyte or wide character
PERF-RECORD(1)                                                                                                                                                            perf Manual                                                                                                                                                            PERF-RECORD(1)

NAME
       perf-record - Run a command and record its profile into perf.data

SYNOPSIS
       perf record [-e <EVENT> | --event=EVENT] [-a] <command>
       perf record [-e <EVENT> | --event=EVENT] [-a]
man: command exited with status 127: col -b -p -x | sed -e '/^[[:space:]]*$/{ N; /^[[:space:]]*\n[[:space:]]*$/D; }'
```
