### PR TITLE
Adding libkf5notifications-dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ add-apt-repository ppa:kubuntu-ppa/backports
 apt-get update
 apt-get install libkf5threadweaver-dev libkf5i18n-dev libkf5configwidgets-dev \
     libkf5coreaddons-dev libkf5itemviews-dev libkf5itemmodels-dev libkf5kio-dev \
-    libkf5solid-dev libkf5windowsystem-dev libelf-dev libdw-dev cmake \
-    extra-cmake-modules gettext libqt5svg5-dev
+    libkf5solid-dev libkf5windowsystem-dev libkf5notifications-dev libelf-dev \
+    libdw-dev cmake extra-cmake-modules gettext libqt5svg5-dev
 ```
 
 ### On Fedora


### PR DESCRIPTION
I'm not tracking other distros, there similar fixes might be needed.