### PR TITLE
LBR unwinding method processing enhancement for Disassembly

### DIFF
--- a/src/models/data.h
+++ b/src/models/data.h
@@ -420,6 +420,17 @@ struct BottomUpResults
         return parent;
     }
 
+    template<typename FrameCallback>
+    const BottomUp* addDisasmEvent(int type, quint64 cost, const QVector<qint32>& frames, FrameCallback frameCallback)
+    {
+        auto parent = &root;
+        foreachFrame(frames, [this, type, cost, &parent, frameCallback](const Data::Symbol &symbol, const Data::Location &location) {
+            frameCallback(symbol, location);
+            return true;
+        });
+        return parent;
+    }
+
 private:
     quint32 maxBottomUpId = 0;
 

--- a/src/parsers/perf/perfparser.cpp
+++ b/src/parsers/perf/perfparser.cpp
@@ -291,13 +291,14 @@ QDebug operator<<(QDebug stream, const SampleCost& sampleCost)
 struct Sample : Record
 {
     QVector<qint32> frames;
+    QVector<qint32> disasmFrames;
     quint8 guessedFrames = 0;
     QVector<SampleCost> costs;
 };
 
 QDataStream& operator>>(QDataStream& stream, Sample& sample)
 {
-    return stream >> static_cast<Record&>(sample) >> sample.frames >> sample.guessedFrames >> sample.costs;
+    return stream >> static_cast<Record&>(sample) >> sample.frames >> sample.guessedFrames >> sample.costs >> sample.disasmFrames;
 }
 
 QDebug operator<<(QDebug stream, const Sample& sample)
@@ -305,7 +306,8 @@ QDebug operator<<(QDebug stream, const Sample& sample)
     stream.noquote().nospace() << "Sample{" << static_cast<const Record&>(sample) << ", "
                                << "frames=" << sample.frames << ", "
                                << "guessedFrames=" << sample.guessedFrames << ", "
-                               << "costs=" << sample.costs << "}";
+                               << "costs=" << sample.costs << ", "
+                               << "disasmFrames=" << sample.disasmFrames << "}";
     return stream;
 }
 
@@ -1048,6 +1050,10 @@ public:
                                   << " (" << symbol.binary << ")\n";
             }
         };
+
+        bool hasStackBranch = !sample.disasmFrames.empty();
+        if (hasStackBranch)
+            bottomUpResult.addDisasmEvent(type, sampleCost.cost, sample.disasmFrames, frameCallback);
 
         bottomUpResult.addEvent(type, sampleCost.cost, sample.frames, frameCallback);
 


### PR DESCRIPTION
Hello, Milian.

Could you please review the changes to add LBR unwinding method proper processing for Disassembly?
Added disasmFrames traverse to compute Disassembly events costs within function/method for LBR.

Related perfparser merge request is https://github.com/KDAB/perfparser/pull/18

Thank you,
Darya