### PR TITLE
Detect missing callgraph

### DIFF
--- a/src/parsers/perf/perfparser.h
+++ b/src/parsers/perf/perfparser.h
@@ -77,7 +77,7 @@ signals:
     void progress(float progress);
     void stopRequested();
 
-    void exportFailed(const QString& errorMessage);
+    void parserWarning(const QString& errorMessage);
     void exportFinished(const QUrl& url);
 
 private:

--- a/src/resultspage.cpp
+++ b/src/resultspage.cpp
@@ -134,7 +134,7 @@ ResultsPage::ResultsPage(PerfParser* parser, QWidget* parent)
 
         m_resultsDisassemblyPage->setArch(data.cpuArchitecture);
     });
-    connect(parser, &PerfParser::exportFailed, this, &ResultsPage::showError);
+    connect(parser, &PerfParser::parserWarning, this, &ResultsPage::showError);
 
     connect(m_resultsCallerCalleePage, &ResultsCallerCalleePage::navigateToCode, this, &ResultsPage::navigateToCode);
     connect(m_resultsCallerCalleePage, &ResultsCallerCalleePage::navigateToCodeFailed, this, &ResultsPage::showError);


### PR DESCRIPTION
 testing shows that samples recorded without --call-graph have only one frame
 this way we can detect the absence of it

reporting this to the user is not perfect yet. I will wait for your response.