### PR TITLE
add option for user to set stack dump size

### DIFF
--- a/src/recordpage.ui
+++ b/src/recordpage.ui
@@ -320,7 +320,7 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="0">
+         <item row="3" column="0">
           <widget class="QLabel" name="unwindingMethodLabel">
            <property name="toolTip">
             <string>Preferred unwinding method to use while recording perf data</string>
@@ -333,14 +333,14 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
+         <item row="3" column="1">
           <widget class="QComboBox" name="callGraphComboBox">
            <property name="toolTip">
             <string>Preferred unwinding method to use while recording perf data</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
+         <item row="7" column="0">
           <widget class="QLabel" name="sampleCpuLabel">
            <property name="toolTip">
             <string>Record the CPU where an event occurred. This enables the per-CPU event timeline. When this setting is disabled, all events will appear to be associated with CPU #0.</string>
@@ -353,7 +353,7 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
+         <item row="7" column="1">
           <widget class="QCheckBox" name="sampleCpuCheckBox">
            <property name="toolTip">
             <string>Record the CPU where an event occurred. This enables the per-CPU event timeline. When this setting is disabled, all events will appear to be associated with CPU #0.</string>
@@ -366,7 +366,7 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
+         <item row="8" column="0">
           <widget class="QLabel" name="useAioLabel">
            <property name="toolTip">
             <string>&lt;qt&gt;Use asynchronous (Posix AIO) trace writing mode. Asynchronous mode is supported only when linking Perf tool with libc library providing implementation for Posix AIO API.&lt;/qt&gt;</string>
@@ -379,7 +379,7 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
+         <item row="8" column="1">
           <widget class="QCheckBox" name="useAioCheckBox">
            <property name="toolTip">
             <string>&lt;qt&gt;Use asynchronous (Posix AIO) trace writing mode. Asynchronous mode is supported only when linking Perf tool with libc library providing implementation for Posix AIO API.&lt;/qt&gt;</string>
@@ -389,7 +389,7 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="0">
+         <item row="9" column="0">
           <widget class="QLabel" name="bufferSizeLabel">
            <property name="toolTip">
             <string>Set the event buffer size. Increase this value when events are lost during recording. When a byte units is selected, the size is rounded up to have nearest pages power of two value. The number of data pages gets rounded up to the nearest power of two.</string>
@@ -402,7 +402,7 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="1">
+         <item row="9" column="1">
           <widget class="QWidget" name="mmapPagesContainer" native="true">
            <layout class="QHBoxLayout" name="horizontalLayout_2">
             <property name="leftMargin">
@@ -481,7 +481,7 @@
            </layout>
           </widget>
          </item>
-         <item row="5" column="0">
+         <item row="10" column="0">
           <widget class="QLabel" name="compressionLabel">
            <property name="toolTip">
             <string>&lt;qt&gt;Compression using zstd will drastically reduce the size of &lt;tt&gt;perf.data&lt;/tt&gt; files. It is recommended to keep this option enabled. The default uses a fast compression level which already yields very significant space savings. If desired, you can select a slower compression level to save more disk space.&lt;/qt&gt;</string>
@@ -494,14 +494,14 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="1">
+         <item row="10" column="1">
           <widget class="QComboBox" name="compressionComboBox">
            <property name="toolTip">
             <string>&lt;qt&gt;Compression using zstd will drastically reduce the size of &lt;tt&gt;perf.data&lt;/tt&gt; files. It is recommended to keep this option enabled. The default uses a fast compression level which already yields very significant space savings. If desired, you can select a slower compression level to save more disk space.&lt;/qt&gt;</string>
            </property>
           </widget>
          </item>
-         <item row="6" column="0">
+         <item row="11" column="0">
           <widget class="QLabel" name="perfParamsLabel">
            <property name="toolTip">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Free-form entry field for custom perf parameters. Use this field to set advanced options (cf. &lt;tt&gt;man perf record&lt;/tt&gt;).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -514,13 +514,26 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="1">
+         <item row="11" column="1">
           <widget class="QComboBox" name="perfParams">
            <property name="toolTip">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Free-form entry field for custom perf parameters. Use this field to set advanced options (cf. &lt;tt&gt;man perf record&lt;/tt&gt;).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="editable">
             <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QComboBox" name="stackDumpComboBox"/>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="stackSizeLabel">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="text">
+            <string>Stack Dump Size</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
when profiling huge applications the default stack dump of 8192 bytes
might be a little small

I added a combobox where the user can choose between 1024 and 16384

I am thinking about changing the combobox to a editable one to allow the user to change the value to their liking. Is this a good Idea?