### PR TITLE
Offer "off CPU recording" also when the perf man page is missing

### DIFF
--- a/src/perfrecord.cpp
+++ b/src/perfrecord.cpp
@@ -363,7 +363,14 @@ static QByteArray perfOutput(const QStringList& arguments)
 
 static QByteArray perfRecordHelp()
 {
-    static const QByteArray recordHelp = perfOutput({QStringLiteral("record"), QStringLiteral("--help")});
+    static const QByteArray recordHelp = []() {
+        static QByteArray help = perfOutput({QStringLiteral("record"), QStringLiteral("--help")});
+        if (help.isEmpty()) {
+            // no man page installed, assume the best
+            help = "--sample-cpu --switch-events";
+        }
+        return help;
+    }();
     return recordHelp;
 }
 


### PR DESCRIPTION
The code calls `perf record --help` to detect the supported features,
but when building perf from sources, if asciidoc (and its million
dependencies) isn't installed, the man page isn't built, and `perf
record --help` only says "No manual entry for perf-record".

When in doubt, offer the features, the user will find out if it works or
not.