### PR TITLE
Ansi colors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ find_package(KF5 COMPONENTS
     WindowSystem
     Notifications
     IconThemes
+    Parts
     REQUIRED
 )
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ As of now, you will need the following dependencies to build this project:
   - windowsystem
   - notifications
   - iconthemes
+  - parts
 - [KDDockWidgets](https://github.com/KDAB/KDDockWidgets)
   - this library is not yet packaged on most distributions, you'll have to compile it yourself from source
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,6 +91,7 @@ target_link_libraries(hotspot
     KF5::WindowSystem
     KF5::Notifications
     KF5::IconThemes
+    KF5::Parts
     models
     PrefixTickLabels
     KDAB::kddockwidgets

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -106,7 +106,7 @@ int firstAvailableIde()
 }
 
 MainWindow::MainWindow(QWidget* parent)
-    : QMainWindow(parent)
+    : KParts::MainWindow(parent)
     , ui(new Ui::MainWindow)
     , m_parser(new PerfParser(this))
     , m_config(KSharedConfig::openConfig())

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -27,10 +27,10 @@
 
 #pragma once
 
-#include <QMainWindow>
 #include <QScopedPointer>
 #include <QString>
 
+#include <KParts/MainWindow>
 #include <KSharedConfig>
 
 namespace Ui {
@@ -47,7 +47,7 @@ class ResultsPage;
 class RecordPage;
 class SettingsDialog;
 
-class MainWindow : public QMainWindow
+class MainWindow : public KParts::MainWindow
 {
     Q_OBJECT
 

--- a/src/recordpage.h
+++ b/src/recordpage.h
@@ -35,6 +35,7 @@
 #include "processlist.h"
 
 class QTimer;
+class QTemporaryFile;
 
 namespace Ui {
 class RecordPage;
@@ -43,6 +44,10 @@ class RecordPage;
 class PerfRecord;
 class ProcessModel;
 class ProcessFilterModel;
+
+namespace KParts {
+class ReadOnlyPart;
+}
 
 enum RecordType
 {
@@ -85,6 +90,7 @@ private:
     void updateRecordType();
     void appendOutput(const QString& text);
     void setError(const QString& message);
+    void addKonsoleWidget();
 
     QScopedPointer<Ui::RecordPage> ui;
 
@@ -92,6 +98,8 @@ private:
     QString m_resultsFile;
     QElapsedTimer m_recordTimer;
     QTimer* m_updateRuntimeTimer;
+    KParts::ReadOnlyPart* m_konsolePart = nullptr;
+    QTemporaryFile* m_konsoleFile = nullptr;
     MultiConfigWidget* m_multiConfig;
 
     ProcessModel* m_processModel;

--- a/src/recordpage.ui
+++ b/src/recordpage.ui
@@ -72,11 +72,11 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="KUrlComboRequester" name="applicationName" native="true">
+       <widget class="KUrlComboRequester" name="applicationName">
         <property name="toolTip">
          <string>Path to the application to be recorded</string>
         </property>
-        <property name="text" stdset="0">
+        <property name="text">
          <string/>
         </property>
        </widget>
@@ -118,7 +118,7 @@
        </widget>
       </item>
       <item row="3" column="1">
-       <widget class="KUrlRequester" name="workingDirectory" native="true">
+       <widget class="KUrlRequester" name="workingDirectory">
         <property name="toolTip">
          <string>Directory to store the perf data file while recording</string>
         </property>
@@ -264,8 +264,8 @@
        </widget>
       </item>
       <item row="3" column="0" colspan="2">
-       <widget class="KCollapsibleGroupBox" name="perfOptionsBox2" native="true">
-        <property name="title" stdset="0">
+       <widget class="KCollapsibleGroupBox" name="perfOptionsBox2">
+        <property name="title">
          <string>Advanced</string>
         </property>
         <layout class="QFormLayout" name="formLayout_3">
@@ -286,7 +286,7 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="KUrlRequester" name="outputFile" native="true">
+          <widget class="KUrlRequester" name="outputFile">
            <property name="toolTip">
             <string>Path to the file location, where perf will write its output to</string>
            </property>
@@ -569,7 +569,7 @@
      <property name="title">
       <string>Record Output</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
+     <layout class="QVBoxLayout" name="recordOutputBoxLayout">
       <item>
        <widget class="QTextEdit" name="perfResultsTextEdit">
         <property name="font">
@@ -605,6 +605,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>KUrlComboRequester</class>
+   <extends>KUrlRequester</extends>
+   <header>kurlrequester.h</header>
+  </customwidget>
+  <customwidget>
    <class>KUrlRequester</class>
    <extends>QWidget</extends>
    <header>kurlrequester.h</header>
@@ -620,11 +625,6 @@
    <extends>QFrame</extends>
    <header>kmessagewidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>KUrlComboRequester</class>
-   <extends>KUrlRequester</extends>
-   <header>kurlrequester.h</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
some programs use ansi escape codes to display color. Currently this breaks the output a bit by inserting unprintable characters.

This change contains a small parser that turns the sequences into html to display the colors correctly.

Stuff that might not work correctly:
- combination of insertHtml and insertText
- some text formating might break in insertHtml

I would recommend adding an option to switch between removed escape sequences and display colors.