### PR TITLE
color the flamegraph in various colors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,7 @@ set(hotspot_SRCS
     resultsdisassemblypage.ui
     timelinewidget.ui
     settingsdialog.ui
+    flamegraphsettings.ui
 
     # resources:
     resources.qrc

--- a/src/flamegraph.cpp
+++ b/src/flamegraph.cpp
@@ -274,10 +274,78 @@ QBrush brushImpl(uint hash, BrushType type)
     return brushes.at(hash % brushes.size());
 }
 
-template<typename T>
-QBrush brush(const T& entry, BrushType type)
+QBrush brushBinary(const Data::Symbol& symbol)
 {
-    return brushImpl(qHash(entry), type);
+    static QHash<QString, QBrush> brushes;
+
+    auto& brush = brushes[symbol.binary];
+    if (brush == QBrush()) {
+        brush = brushImpl(qHash(symbol.binary), BrushType::Hot);
+    }
+    return brush;
+}
+
+QBrush brushKernel(const Data::Symbol& symbol)
+{
+    static QBrush kernel(QColor(255, 0, 0, 125));
+    static QBrush user(QColor(0, 0, 255, 125));
+
+    if (symbol.isKernel) {
+        return kernel;
+    }
+    return user;
+}
+
+bool isInPathList(const QStringList& paths, const QString& subPath)
+{
+    auto containsSubPath = [subPath](const auto& path) { return subPath.startsWith(path); };
+
+    return std::any_of(paths.cbegin(), paths.cend(), containsSubPath);
+}
+
+bool isSystemPath(const QString& path)
+{
+    return isInPathList(Settings::instance()->systemPaths(), path);
+}
+
+bool isUserPath(const QString& path)
+{
+    return isInPathList(Settings::instance()->userPaths(), path);
+}
+
+QBrush brushSystem(const Data::Symbol& symbol)
+{
+    static QBrush system(QColor(0, 125, 0, 125));
+    static QBrush user(QColor(200, 200, 0, 125));
+    static QBrush unkown(QColor(50, 50, 50, 125));
+
+    // I have seen [ only on kernel calls
+    if (symbol.path.isEmpty() || symbol.path.startsWith(QLatin1Char('['))) {
+        return unkown;
+    } else if (isSystemPath(symbol.path)) {
+        if (isUserPath(symbol.path)) {
+            return user;
+        }
+        return system;
+    }
+    return user;
+}
+
+QBrush brush(const Data::Symbol& entry, Settings::ColorScheme scheme)
+{
+    switch (scheme) {
+    case Settings::ColorScheme::Binary:
+        return brushBinary(entry);
+    case Settings::ColorScheme::Kernel:
+        return brushKernel(entry);
+    case Settings::ColorScheme::System:
+        return brushSystem(entry);
+    case Settings::ColorScheme::Default:
+        return brushImpl(qHash(entry), BrushType::Hot);
+    case Settings::ColorScheme::NumColorSchemes:
+        Q_UNREACHABLE();
+    }
+    return QBrush();
 }
 
 /**
@@ -341,7 +409,7 @@ void toGraphicsItems(const Data::Costs& costs, int type, const QVector<Tree>& da
         if (!item) {
             item = new FrameGraphicsItem(costs.cost(type, row.id), costs.unit(type), row.symbol, parent);
             item->setPen(parent->pen());
-            item->setBrush(brush(row.symbol, BrushType::Hot));
+            item->setBrush(brush(row.symbol, Settings::instance()->colorScheme()));
         } else {
             item->setCost(item->cost() + costs.cost(type, row.id));
         }
@@ -403,6 +471,15 @@ SearchResults applySearch(FrameGraphicsItem* item, const QString& searchValue)
 }
 }
 
+void updateFlameGraphColorScheme(FrameGraphicsItem* item, Settings::ColorScheme scheme)
+{
+    item->setBrush(brush(item->symbol(), scheme));
+    const auto children = item->childItems();
+    for (const auto& child : children) {
+        updateFlameGraphColorScheme(static_cast<FrameGraphicsItem*>(child), scheme);
+    }
+}
+
 FlameGraph::FlameGraph(QWidget* parent, Qt::WindowFlags flags)
     : QWidget(parent, flags)
     , m_costSource(new QComboBox(this))
@@ -410,6 +487,8 @@ FlameGraph::FlameGraph(QWidget* parent, Qt::WindowFlags flags)
     , m_view(new QGraphicsView(this))
     , m_displayLabel(new KSqueezedTextLabel(this))
     , m_searchResultsLabel(new QLabel(this))
+    , m_colorSchemeLabel(new QLabel(this))
+    , m_colorSchemeSelector(new QComboBox(this))
 {
     m_displayLabel->setTextElideMode(Qt::ElideRight);
     qRegisterMetaType<FrameGraphicsItem*>();
@@ -500,6 +579,8 @@ FlameGraph::FlameGraph(QWidget* parent, Qt::WindowFlags flags)
     controls->layout()->addWidget(collapseRecursionCheckbox);
     controls->layout()->addWidget(costThreshold);
     controls->layout()->addWidget(m_searchInput);
+    controls->layout()->addWidget(m_colorSchemeLabel);
+    controls->layout()->addWidget(m_colorSchemeSelector);
 
     m_displayLabel->setWordWrap(true);
     m_displayLabel->setTextInteractionFlags(m_displayLabel->textInteractionFlags() | Qt::TextSelectableByMouse);
@@ -529,6 +610,37 @@ FlameGraph::FlameGraph(QWidget* parent, Qt::WindowFlags flags)
     connect(m_resetAction, &QAction::triggered, this, [this]() { selectItem(0); });
     addAction(m_resetAction);
     updateNavigationActions();
+
+    m_colorSchemeLabel->setText(tr("Color Scheme:"));
+
+    m_colorSchemeSelector->addItem(tr("Default"), QVariant::fromValue(Settings::ColorScheme::Default));
+    m_colorSchemeSelector->addItem(tr("Binary"), QVariant::fromValue(Settings::ColorScheme::Binary));
+    m_colorSchemeSelector->addItem(tr("Kernel"), QVariant::fromValue(Settings::ColorScheme::Kernel));
+    m_colorSchemeSelector->addItem(tr("System"), QVariant::fromValue(Settings::ColorScheme::System));
+
+    auto setColorScheme = [this](Settings::ColorScheme scheme) {
+        Settings::instance()->setColorScheme(scheme);
+
+        if (m_rootItem) {
+            const auto children = m_rootItem->childItems();
+            // don't recolor the root item
+            for (const auto& child : children) {
+                updateFlameGraphColorScheme(static_cast<FrameGraphicsItem*>(child), scheme);
+            }
+        }
+    };
+
+    connect(m_colorSchemeSelector, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this, setColorScheme] {
+        setColorScheme(m_colorSchemeSelector->currentData().value<Settings::ColorScheme>());
+    });
+
+    connect(Settings::instance(), &Settings::pathsChanged, this, [setColorScheme] {
+        if (Settings::instance()->colorScheme() == Settings::ColorScheme::System) {
+            // setColorScheme triggers a redraw
+            // we only need to redraw the flamegraph if the current color scheme is affected by the changed paths
+            setColorScheme(Settings::ColorScheme::System);
+        }
+    });
 }
 
 FlameGraph::~FlameGraph() = default;

--- a/src/flamegraph.h
+++ b/src/flamegraph.h
@@ -99,6 +99,8 @@ private:
     QAction* m_resetAction = nullptr;
     QPushButton* m_backButton = nullptr;
     QPushButton* m_forwardButton = nullptr;
+    QLabel* m_colorSchemeLabel = nullptr;
+    QComboBox* m_colorSchemeSelector = nullptr;
     const FrameGraphicsItem* m_tooltipItem = nullptr;
     FrameGraphicsItem* m_rootItem = nullptr;
     QVector<FrameGraphicsItem*> m_selectionHistory;

--- a/src/flamegraphsettings.ui
+++ b/src/flamegraphsettings.ui
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FlamegraphSettings</class>
+ <widget class="QWidget" name="FlamegraphSettings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>445</width>
+    <height>402</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout_2">
+   <item row="0" column="0">
+    <widget class="QLabel" name="userPathsLabel">
+     <property name="text">
+      <string>User Paths:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="KEditListWidget" name="userPaths" native="true"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="systemPathsLabel">
+     <property name="text">
+      <string>System Paths:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="KEditListWidget" name="systemPaths" native="true"/>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>KEditListWidget</class>
+   <extends>QWidget</extends>
+   <header>keditlistwidget.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -210,6 +210,15 @@ MainWindow::MainWindow(QWidget* parent)
 
         connect(Settings::instance(), &Settings::collapseDepthChanged, this,
                 [this](int collapseDepth) { m_config->group("Settings").writeEntry("collapseDepth", collapseDepth); });
+
+        const QStringList userPaths = {QDir::homePath()};
+        const QStringList systemPaths = {QDir::rootPath()};
+        settings->setPaths(m_config->group("PathSettings").readEntry("userPaths", userPaths),
+                           m_config->group("PathSettings").readEntry("systemPaths", systemPaths));
+        connect(Settings::instance(), &Settings::pathsChanged, this, [this, settings] {
+            m_config->group("PathSettings").writeEntry("userPaths", settings->userPaths());
+            m_config->group("PathSettings").writeEntry("systemPaths", settings->systemPaths());
+        });
     }
 
     auto* prettifySymbolsAction = ui->viewMenu->addAction(tr("Prettify Symbols"));

--- a/src/models/data.h
+++ b/src/models/data.h
@@ -47,7 +47,7 @@ QString prettifySymbol(const QString& symbol);
 struct Symbol
 {
     Symbol(const QString& symbol = {}, const quint64& relAddr = 0, const quint64& size = 0, const QString& binary = {},
-           const QString& path = {}, const QString& actualPath = {})
+           const QString& path = {}, const QString& actualPath = {}, bool isKernel = false)
         : symbol(symbol)
         , prettySymbol(Data::prettifySymbol(symbol))
         , relAddr(relAddr)
@@ -55,6 +55,7 @@ struct Symbol
         , binary(binary)
         , path(path)
         , actualPath(actualPath)
+        , isKernel(isKernel)
     {
     }
 
@@ -72,6 +73,7 @@ struct Symbol
     QString path;
     // actual file path
     QString actualPath;
+    bool isKernel = false;
 
     bool operator<(const Symbol& rhs) const
     {

--- a/src/parsers/perf/perfparser.cpp
+++ b/src/parsers/perf/perfparser.cpp
@@ -951,14 +951,15 @@ public:
     {
         // empty symbol was added in addLocation already
         Q_ASSERT(bottomUpResult.symbols.size() > symbol.id);
-        // TODO: isKernel information
         const auto symbolString = strings.value(symbol.symbol.name.id);
         const auto relAddr = symbol.symbol.relAddr;
         const auto size = symbol.symbol.size;
         const auto binaryString = strings.value(symbol.symbol.binary.id);
         const auto pathString = strings.value(symbol.symbol.path.id);
         const auto actualPathString = strings.value(symbol.symbol.actualPath.id);
-        bottomUpResult.symbols[symbol.id] = {symbolString, relAddr, size, binaryString, pathString, actualPathString};
+        const auto isKernel = symbol.symbol.isKernel;
+        bottomUpResult.symbols[symbol.id] = {symbolString, relAddr,          size,    binaryString,
+                                             pathString,   actualPathString, isKernel};
 
         // Count total and missing symbols per module for error report
         auto& numSymbols = numSymbolsByModule[symbol.symbol.binary.id];

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -19,6 +19,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <QDir>
+
 #include "settings.h"
 
 Settings* Settings::instance()
@@ -49,5 +51,22 @@ void Settings::setCollapseDepth(int depth)
     if (m_collapseDepth != depth) {
         m_collapseDepth = depth;
         emit collapseDepthChanged(m_collapseDepth);
+    }
+}
+
+void Settings::setColorScheme(Settings::ColorScheme scheme)
+{
+    if (m_colorScheme != scheme) {
+        m_colorScheme = scheme;
+        emit colorSchemeChanged(m_colorScheme);
+    }
+}
+
+void Settings::setPaths(const QStringList& userPaths, const QStringList& systemPaths)
+{
+    if (m_userPaths != userPaths || m_systemPaths != systemPaths) {
+        m_userPaths = userPaths;
+        m_systemPaths = systemPaths;
+        emit pathsChanged();
     }
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -29,6 +29,16 @@ class Settings : public QObject
     Q_DISABLE_COPY(Settings)
 
 public:
+    enum class ColorScheme : int
+    {
+        Default,
+        Binary,
+        Kernel,
+        System,
+        NumColorSchemes
+    };
+    Q_ENUM(ColorScheme);
+
     static Settings* instance();
 
     bool prettifySymbols() const
@@ -46,15 +56,34 @@ public:
         return m_collapseDepth;
     }
 
+    ColorScheme colorScheme() const
+    {
+        return m_colorScheme;
+    }
+
+    QStringList userPaths() const
+    {
+        return m_userPaths;
+    }
+
+    QStringList systemPaths() const
+    {
+        return m_systemPaths;
+    }
+
 signals:
     void prettifySymbolsChanged(bool);
     void collapseTemplatesChanged(bool);
     void collapseDepthChanged(int);
+    void colorSchemeChanged(ColorScheme);
+    void pathsChanged();
 
 public slots:
     void setPrettifySymbols(bool prettifySymbols);
     void setCollapseTemplates(bool collapseTemplates);
     void setCollapseDepth(int depth);
+    void setColorScheme(ColorScheme scheme);
+    void setPaths(const QStringList& userPaths, const QStringList& systemPaths);
 
 private:
     Settings() = default;
@@ -63,4 +92,7 @@ private:
     bool m_prettifySymbols = true;
     bool m_collapseTemplates = true;
     int m_collapseDepth = 1;
+    ColorScheme m_colorScheme = ColorScheme::Default;
+    QStringList m_userPaths;
+    QStringList m_systemPaths;
 };

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -33,6 +33,7 @@
 
 namespace Ui {
 class SettingsDialog;
+class FlamegraphSettings;
 }
 
 class SettingsDialog : public KPageDialog
@@ -57,7 +58,9 @@ public:
 
 private:
     void addPathSettingsPage();
+    void addFlamegraphPage();
 
     std::unique_ptr<Ui::SettingsDialog> unwindPage;
+    std::unique_ptr<Ui::FlamegraphSettings> flamegraphPage;
     MultiConfigWidget* m_configs;
 };


### PR DESCRIPTION
this patch allows the user to color the flamegraph by various criteria
default: the default color scheme
binary: symbols in the same binary have the same color (duplicates are
allowed)
kernel: mark symbols in kernel red and in userspace blue
system: mark symbols in system files green and user files yellow

closes #80