### PR TITLE
Collapse templates

### DIFF
--- a/src/flamegraph.cpp
+++ b/src/flamegraph.cpp
@@ -416,10 +416,16 @@ FlameGraph::FlameGraph(QWidget* parent, Qt::WindowFlags flags)
 
     m_costSource->setToolTip(i18n("Select the data source that should be visualized in the flame graph."));
 
-    connect(Settings::instance(), &Settings::prettifySymbolsChanged, this, [this]() {
+    const auto updateHelper = [this]() {
         m_scene->update(m_scene->sceneRect());
         updateTooltip();
-    });
+    };
+
+    connect(Settings::instance(), &Settings::prettifySymbolsChanged, this, updateHelper);
+
+    connect(Settings::instance(), &Settings::collapseTemplatesChanged, this, updateHelper);
+
+    connect(Settings::instance(), &Settings::collapseDepthChanged, this, updateHelper);
 
     m_scene->setItemIndexMethod(QGraphicsScene::NoIndex);
     m_view->setScene(m_scene);

--- a/src/models/callercalleemodel.cpp
+++ b/src/models/callercalleemodel.cpp
@@ -33,12 +33,19 @@
 CallerCalleeModel::CallerCalleeModel(QObject* parent)
     : HashModel(parent)
 {
-    connect(Settings::instance(), &Settings::prettifySymbolsChanged, this, [this]() {
+    auto prettifySymbolsHelper = [this]() {
         if (rowCount() == 0) {
             return;
         }
+
         emit dataChanged(index(0, Symbol), index(rowCount() - 1, Symbol));
-    });
+    };
+
+    connect(Settings::instance(), &Settings::prettifySymbolsChanged, this, prettifySymbolsHelper);
+
+    connect(Settings::instance(), &Settings::collapseTemplatesChanged, this, prettifySymbolsHelper);
+
+    connect(Settings::instance(), &Settings::collapseDepthChanged, this, prettifySymbolsHelper);
 }
 
 CallerCalleeModel::~CallerCalleeModel() = default;

--- a/src/models/callercalleemodel.h
+++ b/src/models/callercalleemodel.h
@@ -85,12 +85,19 @@ public:
         : HashModel<Data::SymbolCostMap, ModelImpl>(parent)
     {
         using Parent = HashModel<Data::SymbolCostMap, ModelImpl>;
-        Parent::connect(Settings::instance(), &Settings::prettifySymbolsChanged, this, [this]() {
+
+        auto dataChangedHelper = [this]() {
             if (Parent::rowCount() == 0) {
                 return;
             }
             emit Parent::dataChanged(Parent::index(0, Symbol), Parent::index(Parent::rowCount() - 1, Symbol));
-        });
+        };
+
+        Parent::connect(Settings::instance(), &Settings::prettifySymbolsChanged, this, dataChangedHelper);
+
+        Parent::connect(Settings::instance(), &Settings::collapseTemplatesChanged, this, dataChangedHelper);
+
+        Parent::connect(Settings::instance(), &Settings::collapseDepthChanged, this, dataChangedHelper);
     }
 
     virtual ~SymbolCostModelImpl() = default;

--- a/src/models/treemodel.cpp
+++ b/src/models/treemodel.cpp
@@ -39,12 +39,18 @@ AbstractTreeModel::~AbstractTreeModel() = default;
 BottomUpModel::BottomUpModel(QObject* parent)
     : CostTreeModel(parent)
 {
-    connect(Settings::instance(), &Settings::prettifySymbolsChanged, this, [this]() {
+    auto prettifySymbolsHelper = [this]() {
         if (rowCount() == 0) {
             return;
         }
         emit dataChanged(index(0, Symbol), index(rowCount() - 1, Symbol));
-    });
+    };
+
+    connect(Settings::instance(), &Settings::prettifySymbolsChanged, this, prettifySymbolsHelper);
+
+    connect(Settings::instance(), &Settings::collapseTemplatesChanged, this, prettifySymbolsHelper);
+
+    connect(Settings::instance(), &Settings::collapseDepthChanged, this, prettifySymbolsHelper);
 }
 
 BottomUpModel::~BottomUpModel() = default;
@@ -107,12 +113,19 @@ int BottomUpModel::numColumns() const
 TopDownModel::TopDownModel(QObject* parent)
     : CostTreeModel(parent)
 {
-    connect(Settings::instance(), &Settings::prettifySymbolsChanged, this, [this]() {
+
+    auto prettifySymbolsHelper = [this]() {
         if (rowCount() == 0) {
             return;
         }
         emit dataChanged(index(0, Symbol), index(rowCount() - 1, Symbol));
-    });
+    };
+
+    connect(Settings::instance(), &Settings::prettifySymbolsChanged, this, prettifySymbolsHelper);
+
+    connect(Settings::instance(), &Settings::collapseTemplatesChanged, this, prettifySymbolsHelper);
+
+    connect(Settings::instance(), &Settings::collapseDepthChanged, this, prettifySymbolsHelper);
 }
 
 TopDownModel::~TopDownModel() = default;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -34,3 +34,19 @@ void Settings::setPrettifySymbols(bool prettifySymbols)
         emit prettifySymbolsChanged(m_prettifySymbols);
     }
 }
+
+void Settings::setCollapseTemplates(bool collapseTemplates)
+{
+    if (m_collapseTemplates != collapseTemplates) {
+        m_collapseTemplates = collapseTemplates;
+        emit collapseTemplatesChanged(m_collapseTemplates);
+    }
+}
+
+void Settings::setCollapseDepth(int depth)
+{
+    if (m_collapseDepth != depth) {
+        m_collapseDepth = depth;
+        emit collapseDepthChanged(m_collapseDepth);
+    }
+}

--- a/src/settings.h
+++ b/src/settings.h
@@ -36,15 +36,31 @@ public:
         return m_prettifySymbols;
     }
 
+    bool collapseTemplates() const
+    {
+        return m_collapseTemplates;
+    }
+
+    int collapseDepth() const
+    {
+        return m_collapseDepth;
+    }
+
 signals:
     void prettifySymbolsChanged(bool);
+    void collapseTemplatesChanged(bool);
+    void collapseDepthChanged(int);
 
 public slots:
     void setPrettifySymbols(bool prettifySymbols);
+    void setCollapseTemplates(bool collapseTemplates);
+    void setCollapseDepth(int depth);
 
 private:
     Settings() = default;
     ~Settings() = default;
 
     bool m_prettifySymbols = true;
+    bool m_collapseTemplates = true;
+    int m_collapseDepth = 1;
 };


### PR DESCRIPTION
when working with template heavy code the symbol names can get quite long
this patch allows the user to collapse the arguments to <...>

![grafik](https://user-images.githubusercontent.com/82457690/123794127-cd175900-d8e2-11eb-8ccb-21beefe53138.png)
