### PR TITLE
optimize filtering

### DIFF
--- a/src/models/costproxy.h
+++ b/src/models/costproxy.h
@@ -1,0 +1,70 @@
+/*
+  costproxy.h
+
+  This file is part of Hotspot, the Qt GUI for performance analysis.
+
+  Copyright (C) 2016-2021 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Lieven Hey <lieven.hey@kdab.com>
+
+  Licensees holding valid commercial KDAB Hotspot licenses may use this file in
+  accordance with Hotspot Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef COSTPROXY_H
+#define COSTPROXY_H
+
+#include <QSortFilterProxyModel>
+
+template<typename Model>
+class CostProxy : public QSortFilterProxyModel
+{
+public:
+    explicit CostProxy(QObject* parent = nullptr)
+        : QSortFilterProxyModel(parent)
+    {
+        setRecursiveFilteringEnabled(true);
+        setDynamicSortFilter(true);
+    }
+
+protected:
+    bool filterAcceptsRow(int source_row, const QModelIndex& parent) const override
+    {
+        Q_UNUSED(source_row);
+
+        if (!parent.isValid())
+            return false;
+
+        const auto* model = qobject_cast<Model*>(sourceModel());
+        Q_ASSERT(model);
+
+        const auto* item = model->itemFromIndex(parent);
+        if (!item) {
+            return false;
+        }
+
+        const auto needle = filterRegExp().pattern();
+
+        if (item->symbol.symbol.indexOf(needle) == -1 && item->symbol.binary.indexOf(needle) == -1) {
+            return false;
+        }
+
+        return true;
+    }
+};
+
+#endif // COSTPROXY_H

--- a/src/models/treemodel.h
+++ b/src/models/treemodel.h
@@ -42,7 +42,6 @@ public:
     {
         SortRole = Qt::UserRole,
         TotalCostRole,
-        FilterRole,
         SymbolRole
     };
 };
@@ -151,10 +150,7 @@ public:
             return {};
         }
 
-        if (role == FilterRole) {
-            // TODO: optimize
-            return QString(Util::formatSymbol(item->symbol, false) + item->symbol.binary);
-        } else if (role == SymbolRole) {
+        if (role == SymbolRole) {
             return QVariant::fromValue(item->symbol);
         } else {
             auto ret = rowData(item, index.column(), role);
@@ -185,7 +181,6 @@ public:
         endResetModel();
     }
 
-private:
     const TreeNode* itemFromIndex(const QModelIndex& index) const
     {
         if (!index.isValid() || index.column() >= numColumns()) {
@@ -210,6 +205,7 @@ private:
         }
     }
 
+private:
     QModelIndex indexFromItem(const TreeNode* item, int column) const
     {
         if (!item || column < 0 || column >= numColumns()) {

--- a/src/resultsutil.cpp
+++ b/src/resultsutil.cpp
@@ -67,18 +67,14 @@ void connectFilter(QLineEdit* filter, QSortFilterProxyModel* proxy)
     QObject::connect(filter, &QLineEdit::textChanged, timer, [timer]() { timer->start(300); });
 }
 
-void setupTreeView(QTreeView* view, QLineEdit* filter, QAbstractItemModel* model, int initialSortColumn, int sortRole,
-                   int filterRole)
+void setupTreeView(QTreeView* view, QLineEdit* filter, QSortFilterProxyModel* model, int initialSortColumn,
+                   int sortRole)
 {
-    auto proxy = new QSortFilterProxyModel(view);
-    proxy->setRecursiveFilteringEnabled(true);
-    proxy->setSortRole(sortRole);
-    proxy->setFilterRole(filterRole);
-    proxy->setSourceModel(model);
-    connectFilter(filter, proxy);
+    model->setSortRole(sortRole);
+    connectFilter(filter, model);
 
     view->sortByColumn(initialSortColumn, Qt::DescendingOrder);
-    view->setModel(proxy);
+    view->setModel(model);
     setupHeaderView(view);
 }
 

--- a/src/resultsutil.h
+++ b/src/resultsutil.h
@@ -29,6 +29,7 @@
 
 #include <functional>
 
+#include "models/costproxy.h"
 #include <QFlags>
 
 class QMenu;
@@ -51,13 +52,15 @@ void setupHeaderView(QTreeView* view);
 
 void connectFilter(QLineEdit* filter, QSortFilterProxyModel* proxy);
 
-void setupTreeView(QTreeView* view, QLineEdit* filter, QAbstractItemModel* model, int initialSortColumn, int sortRole,
-                   int filterRole);
+void setupTreeView(QTreeView* view, QLineEdit* filter, QSortFilterProxyModel* model, int initialSortColumn,
+                   int sortRole);
 
 template<typename Model>
 void setupTreeView(QTreeView* view, QLineEdit* filter, Model* model)
 {
-    setupTreeView(view, filter, model, Model::InitialSortColumn, Model::SortRole, Model::FilterRole);
+    auto* proxy = new CostProxy<Model>(view);
+    proxy->setSourceModel(model);
+    setupTreeView(view, filter, qobject_cast<QSortFilterProxyModel*>(proxy), Model::InitialSortColumn, Model::SortRole);
 }
 
 void setupCostDelegate(QAbstractItemModel* model, QTreeView* view, int sortRole, int totalCostRole, int numBaseColumns);


### PR DESCRIPTION
this patch removes the filter role from AbstractTreeModel and adds a
QSortFilterProxyModel named CostProxy to remove memory allocations while
filtering

closes #30