### PR TITLE
fix flamegraph paths are not visible

### DIFF
--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -240,6 +240,13 @@ void SettingsDialog::addFlamegraphPage()
     flamegraphPage->userPaths->insertStringList(Settings::instance()->userPaths());
     flamegraphPage->systemPaths->insertStringList(Settings::instance()->systemPaths());
 
+    connect(Settings::instance(), &Settings::pathsChanged, this, [this] {
+        flamegraphPage->userPaths->clear();
+        flamegraphPage->systemPaths->clear();
+        flamegraphPage->userPaths->insertStringList(Settings::instance()->userPaths());
+        flamegraphPage->systemPaths->insertStringList(Settings::instance()->systemPaths());
+    });
+
     connect(buttonBox(), &QDialogButtonBox::accepted, this, [this] {
         Settings::instance()->setPaths(flamegraphPage->userPaths->items(), flamegraphPage->systemPaths->items());
     });


### PR DESCRIPTION
after closing hotspot and reoping it the paths are empty. This fixes it