### PR TITLE
added custom proxies to remove allocations during filtering

### DIFF
--- a/src/models/CMakeLists.txt
+++ b/src/models/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(models STATIC
     disassemblymodel.cpp
     ../settings.cpp
     ../util.cpp
+    callercalleeproxy.cpp
 )
 
 target_link_libraries(models

--- a/src/models/callercalleemodel.cpp
+++ b/src/models/callercalleemodel.cpp
@@ -119,9 +119,6 @@ QVariant CallerCalleeModel::cell(int column, int role, const Data::Symbol& symbo
 
         column -= m_results.selfCosts.numTypes();
         return m_results.inclusiveCosts.totalCost(column);
-    } else if (role == FilterRole) {
-        // TODO: optimize this
-        return QString(Util::formatSymbol(symbol, false) + symbol.binary);
     } else if (role == Qt::DisplayRole) {
         switch (column) {
         case Symbol:

--- a/src/models/callercalleemodel.h
+++ b/src/models/callercalleemodel.h
@@ -58,7 +58,6 @@ public:
     {
         SortRole = Qt::UserRole,
         TotalCostRole,
-        FilterRole,
         CalleesRole,
         CallersRole,
         SourceMapRole,
@@ -123,7 +122,6 @@ public:
     {
         SortRole = Qt::UserRole,
         TotalCostRole,
-        FilterRole,
         SymbolRole
     };
 
@@ -167,9 +165,6 @@ public:
             return costs[column - NUM_BASE_COLUMNS];
         } else if (role == TotalCostRole && column >= NUM_BASE_COLUMNS) {
             return m_costs.totalCost(column - NUM_BASE_COLUMNS);
-        } else if (role == FilterRole) {
-            // TODO: optimize this
-            return QString(Util::formatSymbol(symbol, false) + symbol.binary);
         } else if (role == Qt::DisplayRole) {
             switch (column) {
             case Symbol:
@@ -250,7 +245,6 @@ public:
     {
         SortRole = Qt::UserRole,
         TotalCostRole,
-        FilterRole,
         LocationRole
     };
 
@@ -303,8 +297,6 @@ public:
                 column -= m_totalCosts.numTypes();
             }
             return m_totalCosts.totalCost(column);
-        } else if (role == FilterRole) {
-            return location;
         } else if (role == Qt::DisplayRole) {
             if (column == Location) {
                 if (location.isEmpty()) {

--- a/src/models/callercalleeproxy.cpp
+++ b/src/models/callercalleeproxy.cpp
@@ -1,0 +1,28 @@
+/*
+  callercalleproxy.cpp
+
+  This file is part of Hotspot, the Qt GUI for performance analysis.
+
+  Copyright (C) 2021 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Lieven Hey <lieven.hey@kdab.com>
+
+  Licensees holding valid commercial KDAB Hotspot licenses may use this file in
+  accordance with Hotspot Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "callercalleeproxy.h"

--- a/src/models/callercalleeproxy.h
+++ b/src/models/callercalleeproxy.h
@@ -1,0 +1,78 @@
+/*
+  callercalleproxy.h
+
+  This file is part of Hotspot, the Qt GUI for performance analysis.
+
+  Copyright (C) 2021 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Lieven Hey <lieven.hey@kdab.com>
+
+  Licensees holding valid commercial KDAB Hotspot licenses may use this file in
+  accordance with Hotspot Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CALLERCALLEEPROXY_H
+#define CALLERCALLEEPROXY_H
+
+#include "data.h"
+#include <QSortFilterProxyModel>
+
+template<typename Model>
+class CallerCalleeProxy : public QSortFilterProxyModel
+{
+public:
+    explicit CallerCalleeProxy(QObject* parent = nullptr)
+        : QSortFilterProxyModel(parent)
+    {
+        setRecursiveFilteringEnabled(true);
+        setDynamicSortFilter(true);
+    }
+
+protected:
+    bool filterAcceptsRow(int source_row, const QModelIndex& parent) const override
+    {
+        Q_UNUSED(parent);
+
+        const auto* model = qobject_cast<Model*>(sourceModel());
+        Q_ASSERT(model);
+
+        const auto needle = filterRegExp().pattern();
+
+        const auto key = model->key(source_row);
+
+        return match(needle, key);
+    }
+
+private:
+    bool match(const QString& needle, const Data::Symbol& symbol) const
+    {
+        if (symbol.symbol.indexOf(needle) == -1 && symbol.binary.indexOf(needle) == -1) {
+            return false;
+        }
+        return true;
+    }
+
+    bool match(const QString& needle, const QString& location) const
+    {
+        if (location.indexOf(needle) == -1) {
+            return false;
+        }
+        return true;
+    }
+};
+
+#endif // CALLERCALLEEPROXY_H

--- a/src/models/hashmodel.h
+++ b/src/models/hashmodel.h
@@ -83,6 +83,11 @@ public:
         return index(row, column);
     }
 
+    typename Rows::key_type key(int row) const
+    {
+        return m_keys.value(row);
+    }
+
 protected:
     void setRows(const Rows& rows)
     {

--- a/src/resultscallercalleepage.cpp
+++ b/src/resultscallercalleepage.cpp
@@ -38,6 +38,7 @@
 #include "resultsutil.h"
 
 #include "models/callercalleemodel.h"
+#include "models/callercalleeproxy.h"
 #include "models/costdelegate.h"
 #include "models/filterandzoomstack.h"
 #include "models/hashmodel.h"
@@ -48,7 +49,7 @@ template<typename Model>
 Model* setupModelAndProxyForView(QTreeView* view)
 {
     auto model = new Model(view);
-    auto proxy = new QSortFilterProxyModel(model);
+    auto proxy = new CallerCalleeProxy<Model>(model);
     proxy->setSourceModel(model);
     proxy->setSortRole(Model::SortRole);
     view->setModel(proxy);
@@ -77,7 +78,7 @@ ResultsCallerCalleePage::ResultsCallerCalleePage(FilterAndZoomStack* filterStack
     ui->setupUi(this);
 
     m_callerCalleeCostModel = new CallerCalleeModel(this);
-    m_callerCalleeProxy = new QSortFilterProxyModel(this);
+    m_callerCalleeProxy = new CallerCalleeProxy<CallerCalleeModel>(this);
     m_callerCalleeProxy->setSourceModel(m_callerCalleeCostModel);
     m_callerCalleeProxy->setSortRole(CallerCalleeModel::SortRole);
     ResultsUtil::connectFilter(ui->callerCalleeFilter, m_callerCalleeProxy);


### PR DESCRIPTION
The caller callee Models still used the old filtering method of creating of concatenating strings and turning these into a QVariant.
This patch add some proxies that can directly filter the model without the need of creating a QVariant or string concatenation.