### PR TITLE
add option to disable column in all tables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,7 @@ set(hotspot_SRCS
     perfoutputwidget.cpp
     perfoutputwidgettext.cpp
     perfoutputwidgetkonsole.cpp
+    costcontextmenu.cpp
 
     # ui files:
     mainwindow.ui

--- a/src/costcontextmenu.cpp
+++ b/src/costcontextmenu.cpp
@@ -1,0 +1,67 @@
+/*
+  costcontextmenu.cpp
+
+  This file is part of Hotspot, the Qt GUI for performance analysis.
+
+  Copyright (C) 2021 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Lieven Hey <lieven.hey@kdab.com>
+
+  Licensees holding valid commercial KDAB Hotspot licenses may use this file in
+  accordance with Hotspot Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "costcontextmenu.h"
+
+#include <QHeaderView>
+#include <QMenu>
+#include <QTreeView>
+
+CostContextMenu::CostContextMenu(QObject* parent)
+    : QObject(parent)
+{
+}
+
+CostContextMenu::~CostContextMenu() = default;
+
+void CostContextMenu::addToMenu(QHeaderView *view, QMenu *menu)
+{
+    for (int i = 1; i < view->count(); ++i) {
+        const auto name = view->model()->headerData(i, Qt::Horizontal).toString();
+        auto* action = menu->addAction(name);
+        action->setCheckable(true);
+        action->setChecked(!view->isSectionHidden(i));
+        connect(action, &QAction::toggled, this, [this, view, name, i](bool visible) { view->setSectionHidden(i, !visible);
+            if (visible) {
+                m_hiddenColumns.remove(name);
+            } else {
+                m_hiddenColumns.insert(name);
+            }
+
+            emit hiddenColumnsChanged();
+        });
+    }
+}
+
+void CostContextMenu::hideColumns(QTreeView *view)
+{
+    const auto model = view->model();
+    for (int i = 1, size = model->columnCount(); i < size; i++) {
+        const auto name = model->headerData(i, Qt::Orientation::Horizontal).toString();
+        view->setColumnHidden(i, m_hiddenColumns.contains(name));
+    }
+}

--- a/src/costcontextmenu.h
+++ b/src/costcontextmenu.h
@@ -1,10 +1,10 @@
 /*
-  costheaderview.h
+  costcontextmenu.h
 
   This file is part of Hotspot, the Qt GUI for performance analysis.
 
-  Copyright (C) 2020 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
-  Author: Milian Wolff <milian.wolff@kdab.com>
+  Copyright (C) 2021 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Lieven Hey <lieven.hey@kdab.com>
 
   Licensees holding valid commercial KDAB Hotspot licenses may use this file in
   accordance with Hotspot Commercial License Agreement provided with the Software.
@@ -27,20 +27,26 @@
 
 #pragma once
 
-#include <QHeaderView>
+#include <QObject>
+#include <QSet>
 
-class CostContextMenu;
+class QTreeView;
+class QHeaderView;
+class QMenu;
 
-class CostHeaderView : public QHeaderView
+class CostContextMenu : public QObject
 {
     Q_OBJECT
 public:
-    explicit CostHeaderView(CostContextMenu* contextMenu, QWidget* parent = nullptr);
-    ~CostHeaderView();
+    explicit CostContextMenu(QObject* parent = nullptr);
+    ~CostContextMenu();
+
+    void addToMenu(QHeaderView* view, QMenu* menu);
+    void hideColumns(QTreeView* view);
+
+signals:
+    void hiddenColumnsChanged();
 
 private:
-    void resizeEvent(QResizeEvent* event) override;
-    void resizeColumns(bool reset);
-
-    bool m_isResizing = false;
+    QSet<QString> m_hiddenColumns;
 };

--- a/src/costheaderview.cpp
+++ b/src/costheaderview.cpp
@@ -33,7 +33,9 @@
 #include <QPainter>
 #include <QScopedValueRollback>
 
-CostHeaderView::CostHeaderView(QWidget* parent)
+#include "costcontextmenu.h"
+
+CostHeaderView::CostHeaderView(CostContextMenu* contextMenu, QWidget* parent)
     : QHeaderView(Qt::Horizontal, parent)
 {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
@@ -77,7 +79,7 @@ CostHeaderView::CostHeaderView(QWidget* parent)
     });
 
     setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(this, &QHeaderView::customContextMenuRequested, this, [this](const QPoint& pos) {
+    connect(this, &QHeaderView::customContextMenuRequested, this, [this, contextMenu](const QPoint& pos) {
         const auto numSections = count();
 
         QMenu menu;
@@ -86,12 +88,7 @@ CostHeaderView::CostHeaderView(QWidget* parent)
 
         if (numSections > 1) {
             auto* subMenu = menu.addMenu(tr("Visible Columns"));
-            for (int i = 1; i < numSections; ++i) {
-                auto* action = subMenu->addAction(model()->headerData(i, Qt::Horizontal).toString());
-                action->setCheckable(true);
-                action->setChecked(!isSectionHidden(i));
-                connect(action, &QAction::toggled, this, [this, i](bool visible) { setSectionHidden(i, !visible); });
-            }
+            contextMenu->addToMenu(this, subMenu);
         }
 
         menu.exec(mapToGlobal(pos));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -26,12 +26,13 @@
 */
 
 #include "mainwindow.h"
+#include "costcontextmenu.h"
 #include "recordpage.h"
 #include "resultspage.h"
 #include "settings.h"
+#include "settingsdialog.h"
 #include "startpage.h"
 #include "ui_mainwindow.h"
-#include "settingsdialog.h"
 #include "ui_settingsdialog.h"
 
 #include <QApplication>

--- a/src/resultsbottomuppage.cpp
+++ b/src/resultsbottomuppage.cpp
@@ -74,17 +74,17 @@ void stackCollapsedExport(QFile& file, int type, const Data::BottomUpResults& re
 }
 }
 
-ResultsBottomUpPage::ResultsBottomUpPage(FilterAndZoomStack* filterStack, PerfParser* parser, QMenu* exportMenu,
-                                         QWidget* parent)
+ResultsBottomUpPage::ResultsBottomUpPage(FilterAndZoomStack* filterStack, PerfParser* parser,
+                                         CostContextMenu* contextMenu, QMenu* exportMenu, QWidget* parent)
     : QWidget(parent)
     , ui(new Ui::ResultsBottomUpPage)
 {
     ui->setupUi(this);
 
     auto bottomUpCostModel = new BottomUpModel(this);
-    ResultsUtil::setupTreeView(ui->bottomUpTreeView, ui->bottomUpSearch, bottomUpCostModel);
+    ResultsUtil::setupTreeView(ui->bottomUpTreeView, contextMenu, ui->bottomUpSearch, bottomUpCostModel);
     ResultsUtil::setupCostDelegate(bottomUpCostModel, ui->bottomUpTreeView);
-    ResultsUtil::setupContextMenu(ui->bottomUpTreeView, bottomUpCostModel, filterStack, this);
+    ResultsUtil::setupContextMenu(ui->bottomUpTreeView, contextMenu, bottomUpCostModel, filterStack, this);
 
     connect(
         parser, &PerfParser::bottomUpDataAvailable, this,

--- a/src/resultsbottomuppage.h
+++ b/src/resultsbottomuppage.h
@@ -43,13 +43,14 @@ class QTreeView;
 
 class PerfParser;
 class FilterAndZoomStack;
+class CostContextMenu;
 
 class ResultsBottomUpPage : public QWidget
 {
     Q_OBJECT
 public:
-    explicit ResultsBottomUpPage(FilterAndZoomStack* filterStack, PerfParser* parser, QMenu* exportMenu,
-                                 QWidget* parent = nullptr);
+    explicit ResultsBottomUpPage(FilterAndZoomStack* filterStack, PerfParser* parser, CostContextMenu* contextMenu,
+                                 QMenu* exportMenu, QWidget* parent = nullptr);
     ~ResultsBottomUpPage();
 
     void clear();

--- a/src/resultscallercalleepage.h
+++ b/src/resultscallercalleepage.h
@@ -43,12 +43,14 @@ class QModelIndex;
 class PerfParser;
 class CallerCalleeModel;
 class FilterAndZoomStack;
+class CostContextMenu;
 
 class ResultsCallerCalleePage : public QWidget
 {
     Q_OBJECT
 public:
-    explicit ResultsCallerCalleePage(FilterAndZoomStack* filterStack, PerfParser* parser, QWidget* parent = nullptr);
+    explicit ResultsCallerCalleePage(FilterAndZoomStack* filterStack, PerfParser* parser, CostContextMenu* contextMenu,
+                                     QWidget* parent = nullptr);
     ~ResultsCallerCalleePage();
 
     void setSysroot(const QString& path);

--- a/src/resultspage.cpp
+++ b/src/resultspage.cpp
@@ -30,6 +30,7 @@
 
 #include "parsers/perf/perfparser.h"
 
+#include "costcontextmenu.h"
 #include "dockwidgetsetup.h"
 #include "resultsbottomuppage.h"
 #include "resultscallercalleepage.h"
@@ -59,13 +60,15 @@ ResultsPage::ResultsPage(PerfParser* parser, QWidget* parent)
     , ui(new Ui::ResultsPage)
     , m_contents(createDockingArea(QStringLiteral("results"), this))
     , m_filterAndZoomStack(new FilterAndZoomStack(this))
+    , m_costContextMenu(new CostContextMenu(this))
     , m_filterMenu(new QMenu(this))
     , m_exportMenu(new QMenu(tr("Export"), this))
-    , m_resultsSummaryPage(new ResultsSummaryPage(m_filterAndZoomStack, parser, this))
-    , m_resultsBottomUpPage(new ResultsBottomUpPage(m_filterAndZoomStack, parser, m_exportMenu, this))
-    , m_resultsTopDownPage(new ResultsTopDownPage(m_filterAndZoomStack, parser, this))
+    , m_resultsSummaryPage(new ResultsSummaryPage(m_filterAndZoomStack, parser, m_costContextMenu, this))
+    , m_resultsBottomUpPage(
+          new ResultsBottomUpPage(m_filterAndZoomStack, parser, m_costContextMenu, m_exportMenu, this))
+    , m_resultsTopDownPage(new ResultsTopDownPage(m_filterAndZoomStack, parser, m_costContextMenu, this))
     , m_resultsFlameGraphPage(new ResultsFlameGraphPage(m_filterAndZoomStack, parser, m_exportMenu, this))
-    , m_resultsCallerCalleePage(new ResultsCallerCalleePage(m_filterAndZoomStack, parser, this))
+    , m_resultsCallerCalleePage(new ResultsCallerCalleePage(m_filterAndZoomStack, parser, m_costContextMenu, this))
     , m_resultsDisassemblyPage(new ResultsDisassemblyPage(this))
     , m_timeLineWidget(new TimeLineWidget(parser, m_filterMenu, m_filterAndZoomStack, this))
     , m_timelineVisible(true)

--- a/src/resultspage.h
+++ b/src/resultspage.h
@@ -54,6 +54,7 @@ class ResultsCallerCalleePage;
 class ResultsDisassemblyPage;
 class FilterAndZoomStack;
 class TimeLineWidget;
+class CostContextMenu;
 
 class ResultsPage : public QWidget
 {
@@ -88,6 +89,7 @@ private:
     QScopedPointer<Ui::ResultsPage> ui;
     KDDockWidgets::MainWindow* m_contents;
     FilterAndZoomStack* m_filterAndZoomStack;
+    CostContextMenu* m_costContextMenu;
     QMenu* m_filterMenu;
     QMenu* m_exportMenu;
     KDDockWidgets::DockWidget* m_summaryPageDock;

--- a/src/resultssummarypage.cpp
+++ b/src/resultssummarypage.cpp
@@ -45,7 +45,8 @@
 #include "models/topproxy.h"
 #include "models/treemodel.h"
 
-ResultsSummaryPage::ResultsSummaryPage(FilterAndZoomStack* filterStack, PerfParser* parser, QWidget* parent)
+ResultsSummaryPage::ResultsSummaryPage(FilterAndZoomStack* filterStack, PerfParser* parser,
+                                       CostContextMenu* contextMenu, QWidget* parent)
     : QWidget(parent)
     , ui(new Ui::ResultsSummaryPage)
 {
@@ -61,8 +62,8 @@ ResultsSummaryPage::ResultsSummaryPage(FilterAndZoomStack* filterStack, PerfPars
     ui->topHotspotsTableView->setSortingEnabled(false);
     ui->topHotspotsTableView->setModel(topHotspotsProxy);
     ResultsUtil::setupCostDelegate<BottomUpModel>(bottomUpCostModel, ui->topHotspotsTableView);
-    ResultsUtil::setupHeaderView(ui->topHotspotsTableView);
-    ResultsUtil::setupContextMenu(ui->topHotspotsTableView, bottomUpCostModel, filterStack, this);
+    ResultsUtil::setupHeaderView(ui->topHotspotsTableView, contextMenu);
+    ResultsUtil::setupContextMenu(ui->topHotspotsTableView, contextMenu, bottomUpCostModel, filterStack, this);
 
     connect(ui->eventSourceComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
             [topHotspotsProxy, this]() {

--- a/src/resultssummarypage.h
+++ b/src/resultssummarypage.h
@@ -39,12 +39,14 @@ class ResultsSummaryPage;
 
 class PerfParser;
 class FilterAndZoomStack;
+class CostContextMenu;
 
 class ResultsSummaryPage : public QWidget
 {
     Q_OBJECT
 public:
-    explicit ResultsSummaryPage(FilterAndZoomStack* filterStack, PerfParser* parser, QWidget* parent = nullptr);
+    explicit ResultsSummaryPage(FilterAndZoomStack* filterStack, PerfParser* parser, CostContextMenu* contextMenu,
+                                QWidget* parent = nullptr);
     ~ResultsSummaryPage();
 
 signals:

--- a/src/resultstopdownpage.cpp
+++ b/src/resultstopdownpage.cpp
@@ -34,16 +34,17 @@
 #include "models/hashmodel.h"
 #include "models/treemodel.h"
 
-ResultsTopDownPage::ResultsTopDownPage(FilterAndZoomStack* filterStack, PerfParser* parser, QWidget* parent)
+ResultsTopDownPage::ResultsTopDownPage(FilterAndZoomStack* filterStack, PerfParser* parser,
+                                       CostContextMenu* contextMenu, QWidget* parent)
     : QWidget(parent)
     , ui(new Ui::ResultsTopDownPage)
 {
     ui->setupUi(this);
 
     auto topDownCostModel = new TopDownModel(this);
-    ResultsUtil::setupTreeView(ui->topDownTreeView, ui->topDownSearch, topDownCostModel);
+    ResultsUtil::setupTreeView(ui->topDownTreeView, contextMenu, ui->topDownSearch, topDownCostModel);
     ResultsUtil::setupCostDelegate(topDownCostModel, ui->topDownTreeView);
-    ResultsUtil::setupContextMenu(ui->topDownTreeView, topDownCostModel, filterStack, this);
+    ResultsUtil::setupContextMenu(ui->topDownTreeView, contextMenu, topDownCostModel, filterStack, this);
 
     connect(parser, &PerfParser::topDownDataAvailable, this,
             [this, topDownCostModel](const Data::TopDownResults& data) {

--- a/src/resultstopdownpage.h
+++ b/src/resultstopdownpage.h
@@ -41,12 +41,14 @@ class QTreeView;
 
 class PerfParser;
 class FilterAndZoomStack;
+class CostContextMenu;
 
 class ResultsTopDownPage : public QWidget
 {
     Q_OBJECT
 public:
-    explicit ResultsTopDownPage(FilterAndZoomStack* filterStack, PerfParser* parser, QWidget* parent = nullptr);
+    explicit ResultsTopDownPage(FilterAndZoomStack* filterStack, PerfParser* parser, CostContextMenu* contextMenu,
+                                QWidget* parent = nullptr);
     ~ResultsTopDownPage();
 
     void clear();

--- a/src/resultsutil.h
+++ b/src/resultsutil.h
@@ -46,21 +46,23 @@ struct Symbol;
 }
 
 class FilterAndZoomStack;
+class CostContextMenu;
 
 namespace ResultsUtil {
-void setupHeaderView(QTreeView* view);
+void setupHeaderView(QTreeView* view, CostContextMenu* contextMenu);
 
 void connectFilter(QLineEdit* filter, QSortFilterProxyModel* proxy);
 
-void setupTreeView(QTreeView* view, QLineEdit* filter, QSortFilterProxyModel* model, int initialSortColumn,
-                   int sortRole);
+void setupTreeView(QTreeView* view, CostContextMenu* contextMenu, QLineEdit* filter, QSortFilterProxyModel* model,
+                   int initialSortColumn, int sortRole);
 
 template<typename Model>
-void setupTreeView(QTreeView* view, QLineEdit* filter, Model* model)
+void setupTreeView(QTreeView* view, CostContextMenu* costContextMenu, QLineEdit* filter, Model* model)
 {
     auto* proxy = new CostProxy<Model>(view);
     proxy->setSourceModel(model);
-    setupTreeView(view, filter, qobject_cast<QSortFilterProxyModel*>(proxy), Model::InitialSortColumn, Model::SortRole);
+    setupTreeView(view, costContextMenu, filter, qobject_cast<QSortFilterProxyModel*>(proxy), Model::InitialSortColumn,
+                  Model::SortRole);
 }
 
 void setupCostDelegate(QAbstractItemModel* model, QTreeView* view, int sortRole, int totalCostRole, int numBaseColumns);
@@ -82,15 +84,17 @@ enum class CallbackAction
 };
 Q_DECLARE_FLAGS(CallbackActions, CallbackAction)
 
-void setupContextMenu(QTreeView* view, int symbolRole, FilterAndZoomStack* filterStack, CallbackActions actions,
+void setupContextMenu(QTreeView* view, CostContextMenu* costContextMenu, int symbolRole,
+                      FilterAndZoomStack* filterStack, CallbackActions actions,
                       std::function<void(CallbackAction action, const Data::Symbol&)> callback);
 
 template<typename Model, typename Context>
-void setupContextMenu(QTreeView* view, Model* /*model*/, FilterAndZoomStack* filterStack, Context* context,
+void setupContextMenu(QTreeView* view, CostContextMenu* costContextMenu, Model* /*model*/,
+                      FilterAndZoomStack* filterStack, Context* context,
                       CallbackActions actions = {CallbackAction::ViewCallerCallee, CallbackAction::OpenEditor,
                                                  CallbackAction::SelectSymbol, CallbackAction::ViewDisassembly})
 {
-    setupContextMenu(view, Model::SymbolRole, filterStack, actions,
+    setupContextMenu(view, costContextMenu, Model::SymbolRole, filterStack, actions,
                      [context](ResultsUtil::CallbackAction action, const Data::Symbol& symbol) {
                          switch (action) {
                          case ResultsUtil::CallbackAction::ViewCallerCallee:


### PR DESCRIPTION
this patch adds a shared context menu that disables columns on all
tables.
The context menu is automatically connected if setupContextMenu is
called

closed #344