### PR TITLE
set kf5auth minimum version to 5.55

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ find_package(KF5 COMPONENTS
 )
 
 find_package(KF5Archive CONFIG)
-find_package(KF5Auth CONFIG)
+find_package(KF5Auth 5.55.0 CONFIG)
 find_package(KDDockWidgets CONFIG)
 set_package_properties(KDDockWidgets PROPERTIES
     PURPOSE "KDDockWidgets is a Qt dock widget library written by KDAB, suitable for replacing QDockWidget and implementing


### PR DESCRIPTION
kf5auth 5.55 introduced AuthCore to remove gui stuff from helpers but
the appimage generation still uses 5.33 which does not support this