### PR TITLE
rename gui classes in settingsdialog

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,9 +63,9 @@ set(hotspot_SRCS
     resultscallercalleepage.ui
     resultsdisassemblypage.ui
     timelinewidget.ui
-    settingsdialog.ui
-    flamegraphsettings.ui
-    debuginfoddialog.ui
+    unwindsettingspage.ui
+    flamegraphsettingspage.ui
+    debuginfodpage.ui
     callgraphwidget.ui
     callgraphsettings.ui
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,7 @@ set(hotspot_SRCS
     flamegraphsettingspage.ui
     debuginfodpage.ui
     callgraphwidget.ui
-    callgraphsettings.ui
+    callgraphsettingspage.ui
 
     # resources:
     resources.qrc

--- a/src/callgraphsettingspage.ui
+++ b/src/callgraphsettingspage.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>CallgraphSettings</class>
- <widget class="QWidget" name="CallgraphSettings">
+ <class>CallgraphSettingsPage</class>
+ <widget class="QWidget" name="CallgraphSettingsPage">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/debuginfodpage.ui
+++ b/src/debuginfodpage.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>DebuginfodDialog</class>
- <widget class="QWidget" name="DebuginfodDialog">
+ <class>DebuginfodPage</class>
+ <widget class="QWidget" name="DebuginfodPage">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/flamegraphsettingspage.ui
+++ b/src/flamegraphsettingspage.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>FlamegraphSettings</class>
- <widget class="QWidget" name="FlamegraphSettings">
+ <class>FlamegraphSettingsPage</class>
+ <widget class="QWidget" name="FlamegraphSettingsPage">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -14,7 +14,7 @@
 #include "settingsdialog.h"
 #include "startpage.h"
 #include "ui_mainwindow.h"
-#include "ui_settingsdialog.h"
+#include "ui_unwindsettingspage.h"
 
 #include <QApplication>
 #include <QFileDialog>

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -7,15 +7,15 @@
 */
 
 #include "settingsdialog.h"
-#include "ui_debuginfoddialog.h"
-#include "ui_flamegraphsettings.h"
-#include "ui_settingsdialog.h"
+#include "ui_debuginfodpage.h"
+#include "ui_flamegraphsettingspage.h"
+#include "ui_unwindsettingspage.h"
 #include "ui_callgraphsettings.h"
 
 #include <KComboBox>
 #include <KUrlRequester>
-#include <kconfiggroup.h>
-#include <ksharedconfig.h>
+#include <KConfigGroup>
+#include <KSharedConfig>
 #include <QKeyEvent>
 #include <QLineEdit>
 #include <settings.h>
@@ -34,9 +34,9 @@ KConfigGroup config()
 
 SettingsDialog::SettingsDialog(QWidget* parent)
     : KPageDialog(parent)
-    , unwindPage(new Ui::SettingsDialog)
-    , flamegraphPage(new Ui::FlamegraphSettings)
-    , debuginfodPage(new Ui::DebuginfodDialog)
+    , unwindPage(new Ui::UnwindSettingsPage)
+    , flamegraphPage(new Ui::FlamegraphSettingsPage)
+    , debuginfodPage(new Ui::DebuginfodPage)
 #if KGRAPHVIEWER_FOUND
     , callgraphSettings(new Ui::CallgraphSettings)
 #endif

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -7,10 +7,10 @@
 */
 
 #include "settingsdialog.h"
+#include "ui_callgraphsettingspage.h"
 #include "ui_debuginfodpage.h"
 #include "ui_flamegraphsettingspage.h"
 #include "ui_unwindsettingspage.h"
-#include "ui_callgraphsettings.h"
 
 #include <KComboBox>
 #include <KUrlRequester>
@@ -38,7 +38,7 @@ SettingsDialog::SettingsDialog(QWidget* parent)
     , flamegraphPage(new Ui::FlamegraphSettingsPage)
     , debuginfodPage(new Ui::DebuginfodPage)
 #if KGRAPHVIEWER_FOUND
-    , callgraphSettings(new Ui::CallgraphSettings)
+    , callgraphPage(new Ui::CallgraphSettingsPage)
 #endif
 {
     addPathSettingsPage();
@@ -272,20 +272,21 @@ void SettingsDialog::addCallgraphPage()
     item->setHeader(tr("Callgraph Settings"));
     item->setIcon(QIcon::fromTheme(QStringLiteral("preferences-system-windows-behavior")));
 
-    callgraphSettings->setupUi(page);
+    callgraphPage->setupUi(page);
 
     connect(Settings::instance(), &Settings::callgraphChanged, this, [this] {
         auto settings = Settings::instance();
-        callgraphSettings->parentSpinBox->setValue(settings->callgraphParentDepth());
-        callgraphSettings->childSpinBox->setValue(settings->callgraphChildDepth());
-        callgraphSettings->currentFunctionColor->setColor(settings->callgraphActiveColor());
-        callgraphSettings->functionColor->setColor(settings->callgraphColor());
+        callgraphPage->parentSpinBox->setValue(settings->callgraphParentDepth());
+        callgraphPage->childSpinBox->setValue(settings->callgraphChildDepth());
+        callgraphPage->currentFunctionColor->setColor(settings->callgraphActiveColor());
+        callgraphPage->functionColor->setColor(settings->callgraphColor());
     });
 
     connect(buttonBox(), &QDialogButtonBox::accepted, this, [this]{
         auto settings = Settings::instance();
-        settings->setCallgraphParentDepth(callgraphSettings->parentSpinBox->value());
-        settings->setCallgraphChildDepth(callgraphSettings->childSpinBox->value());
-        settings->setCallgraphColors(callgraphSettings->currentFunctionColor->color().name(), callgraphSettings->functionColor->color().name());
+        settings->setCallgraphParentDepth(callgraphPage->parentSpinBox->value());
+        settings->setCallgraphChildDepth(callgraphPage->childSpinBox->value());
+        settings->setCallgraphColors(callgraphPage->currentFunctionColor->color().name(),
+                                     callgraphPage->functionColor->color().name());
     });
 }

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -16,7 +16,7 @@ namespace Ui {
 class UnwindSettingsPage;
 class FlamegraphSettingsPage;
 class DebuginfodPage;
-class CallgraphSettings;
+class CallgraphSettingsPage;
 }
 
 class SettingsDialog : public KPageDialog
@@ -48,6 +48,6 @@ private:
     std::unique_ptr<Ui::UnwindSettingsPage> unwindPage;
     std::unique_ptr<Ui::FlamegraphSettingsPage> flamegraphPage;
     std::unique_ptr<Ui::DebuginfodPage> debuginfodPage;
-    std::unique_ptr<Ui::CallgraphSettings> callgraphSettings;
+    std::unique_ptr<Ui::CallgraphSettingsPage> callgraphPage;
     MultiConfigWidget* m_configs;
 };

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -13,9 +13,9 @@
 #include <memory>
 
 namespace Ui {
-class SettingsDialog;
-class FlamegraphSettings;
-class DebuginfodDialog;
+class UnwindSettingsPage;
+class FlamegraphSettingsPage;
+class DebuginfodPage;
 class CallgraphSettings;
 }
 
@@ -45,9 +45,9 @@ private:
     void addDebuginfodPage();
     void addCallgraphPage();
 
-    std::unique_ptr<Ui::SettingsDialog> unwindPage;
-    std::unique_ptr<Ui::FlamegraphSettings> flamegraphPage;
-    std::unique_ptr<Ui::DebuginfodDialog> debuginfodPage;
+    std::unique_ptr<Ui::UnwindSettingsPage> unwindPage;
+    std::unique_ptr<Ui::FlamegraphSettingsPage> flamegraphPage;
+    std::unique_ptr<Ui::DebuginfodPage> debuginfodPage;
     std::unique_ptr<Ui::CallgraphSettings> callgraphSettings;
     MultiConfigWidget* m_configs;
 };

--- a/src/unwindsettingspage.ui
+++ b/src/unwindsettingspage.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>SettingsDialog</class>
- <widget class="QWidget" name="SettingsDialog">
+ <class>UnwindSettingsPage</class>
+ <widget class="QWidget" name="UnwindSettingsPage">
   <property name="modal" stdset="0">
    <bool>false</bool>
   </property>


### PR DESCRIPTION
some names do not make sense anymore (settingsdialog.ui just contains
the unwind settings) so I changes them to more descriptive names

additional changes:
- removed double /* in settings.cpp
- added #ifdef QCustomPlot_FOUND to resultspage.cpp, otherwise the
  dockify call will fail since the compiler doen't know that
  m_frequencyPage is a QWidget