### PR TITLE
initialize m_numTypes in DisassemblyModel

### DIFF
--- a/src/models/disassemblymodel.h
+++ b/src/models/disassemblymodel.h
@@ -47,5 +47,5 @@ public:
 private:
     DisassemblyOutput m_data;
     Data::CallerCalleeResults m_results;
-    int m_numTypes;
+    int m_numTypes = 0;
 };


### PR DESCRIPTION
the value is not initialized and can cause QAbstractHeaderView to crash
this might fix #337