### PR TITLE
add assertion to settings::instance

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -6,13 +6,14 @@
     SPDX-License-Identifier: GPL-2.0-or-later
 */
 
-#include <QDir>
+#include <QThread>
 
 #include "settings.h"
 
 Settings* Settings::instance()
 {
     static Settings settings;
+    Q_ASSERT(QThread::currentThread() == settings.thread());
     return &settings;
 }
 


### PR DESCRIPTION
accessing settings::instance is not thread safe and should only be done
from the main thread