### PR TITLE
fix warning

### DIFF
--- a/src/parsers/perf/perfparser.cpp
+++ b/src/parsers/perf/perfparser.cpp
@@ -1582,7 +1582,7 @@ void PerfParser::filterResults(const Data::FilterAction& filter)
     emit parsingStarted();
     using namespace ThreadWeaver;
     stream() << make_job([this, filter]() {
-        Queue queue(this);
+        Queue queue;
         queue.setMaximumNumberOfThreads(QThread::idealThreadCount());
 
         Data::BottomUpResults bottomUp;


### PR DESCRIPTION
fix QObject: Cannot create children for a parent that is in a different thread