### PR TITLE
Multiple windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,25 +147,32 @@ int main(int argc, char** argv)
     auto applyCliArgs = [&](Settings* settings) {
         if (parser.isSet(sysroot)) {
             settings->setSysroot(parser.value(sysroot));
+            settings->setLastUsedEnvironment({});
         }
         if (parser.isSet(kallsyms)) {
             settings->setKallsyms(parser.value(kallsyms));
+            settings->setLastUsedEnvironment({});
         }
         if (parser.isSet(debugPaths)) {
             settings->setDebugPaths(parser.value(debugPaths));
+            settings->setLastUsedEnvironment({});
         }
         if (parser.isSet(extraLibPaths)) {
             settings->setExtraLibPaths(parser.value(extraLibPaths));
+            settings->setLastUsedEnvironment({});
         }
         if (parser.isSet(appPath)) {
             settings->setAppPath(parser.value(appPath));
+            settings->setLastUsedEnvironment({});
         }
         if (parser.isSet(arch)) {
             settings->setArch(parser.value(arch));
+            settings->setLastUsedEnvironment({});
         }
     };
 
     const auto settings = Settings::instance();
+    settings->loadFromFile();
     applyCliArgs(settings);
 
     auto files = parser.positionalArguments();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -183,18 +183,7 @@ int main(int argc, char** argv)
     while (files.size() > 1) {
         // spawn new instances if we have more than one file argument
         const auto file = files.takeLast();
-        auto process = new QProcess(&app);
-        QObject::connect(process, &QProcess::errorOccurred, &app, [=]() {
-            qWarning() << file << process->errorString();
-        });
-        // the event loop locker prevents the main app from quitting while the child processes are still running
-        // we want to keep them all alive and quit them in one go. detaching isn't as nice, as we would not be
-        // able to quit all apps in one go via Ctrl+C then anymore'
-        QObject::connect(process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished), &app,
-                         [lock = std::make_unique<QEventLoopLocker>()]() mutable { lock.reset(); });
-        auto args = minimalArguments;
-        args.append(file);
-        process->start(app.applicationFilePath(), args);
+        MainWindow::openInNewWindow(file, minimalArguments);
     }
 
     // we now only have at most one file

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,30 +145,22 @@ int main(int argc, char** argv)
     ThreadWeaver::Queue::instance()->setMaximumNumberOfThreads(QThread::idealThreadCount());
 
     auto applyCliArgs = [&](Settings* settings) {
-        if (parser.isSet(sysroot)) {
-            settings->setSysroot(parser.value(sysroot));
-            settings->setLastUsedEnvironment({});
-        }
-        if (parser.isSet(kallsyms)) {
-            settings->setKallsyms(parser.value(kallsyms));
-            settings->setLastUsedEnvironment({});
-        }
-        if (parser.isSet(debugPaths)) {
-            settings->setDebugPaths(parser.value(debugPaths));
-            settings->setLastUsedEnvironment({});
-        }
-        if (parser.isSet(extraLibPaths)) {
-            settings->setExtraLibPaths(parser.value(extraLibPaths));
-            settings->setLastUsedEnvironment({});
-        }
-        if (parser.isSet(appPath)) {
-            settings->setAppPath(parser.value(appPath));
-            settings->setLastUsedEnvironment({});
-        }
-        if (parser.isSet(arch)) {
-            settings->setArch(parser.value(arch));
-            settings->setLastUsedEnvironment({});
-        }
+        using Setter = void (Settings::*)(const QString&);
+        auto applyArg = [&](const QCommandLineOption& arg, Setter setter) {
+            if (parser.isSet(arg)) {
+                // set a custom env when any arg is set on the mainwindow
+                // we don't want to overwrite the previous one's with our custom settings
+                settings->setLastUsedEnvironment({});
+
+                (settings->*setter)(parser.value(arg));
+            }
+        };
+        applyArg(sysroot, &Settings::setSysroot);
+        applyArg(kallsyms, &Settings::setKallsyms);
+        applyArg(debugPaths, &Settings::setDebugPaths);
+        applyArg(extraLibPaths, &Settings::setExtraLibPaths);
+        applyArg(appPath, &Settings::setAppPath);
+        applyArg(arch, &Settings::setArch);
     };
 
     const auto settings = Settings::instance();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -170,8 +170,6 @@ MainWindow::MainWindow(QWidget* parent)
     connect(openNewWindow, &QAction::triggered, this, [this] {
         const auto fileName = QFileDialog::getOpenFileName(this, tr("Open File"), QDir::currentPath(),
                                                            tr("Data Files (perf*.data perf.data.*);;All Files (*)"));
-        QStringList arguments;
-
         QProcess process;
         process.setProgram(qApp->applicationFilePath());
         process.setArguments({fileName});

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -54,6 +54,8 @@ public slots:
     void setCodeNavigationIDE(QAction* action);
     void navigateToCode(const QString& url, int lineNumber, int columnNumber);
 
+    static void openInNewWindow(const QString& file, const QStringList& args = {});
+
 signals:
     void openFileError(const QString& errorMessage);
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -72,7 +72,6 @@ private:
     ResultsPage* m_resultsPage;
     SettingsDialog* m_settingsDialog;
 
-    QString m_lastUsedSettings;
     KRecentFilesAction* m_recentFilesAction = nullptr;
     QAction* m_reloadAction = nullptr;
     QAction* m_exportAction = nullptr;

--- a/src/settings.h
+++ b/src/settings.h
@@ -133,6 +133,13 @@ public:
         return m_costAggregation;
     }
 
+    QString lastUsedEnvironment() const
+    {
+        return m_lastUsedEnvironment;
+    }
+
+    void loadFromFile();
+
 signals:
     void prettifySymbolsChanged(bool);
     void collapseTemplatesChanged(bool);
@@ -149,6 +156,7 @@ signals:
     void archChanged(const QString& arch);
     void objdumpChanged(const QString& objdump);
     void callgraphChanged();
+    void lastUsedEnvironmentChanged(const QString& envName);
 
 public slots:
     void setPrettifySymbols(bool prettifySymbols);
@@ -168,6 +176,7 @@ public slots:
     void setCallgraphChildDepth(int child);
     void setCallgraphColors(const QColor& active, const QColor& inactive);
     void setCostAggregation(CostAggregation costAggregation);
+    void setLastUsedEnvironment(const QString& envName);
 
 private:
     Settings() = default;
@@ -189,6 +198,8 @@ private:
     QString m_appPath;
     QString m_arch;
     QString m_objdump;
+
+    QString m_lastUsedEnvironment;
 
     int m_callgraphParentDepth = 3;
     int m_callgraphChildDepth = 2;

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -51,9 +51,12 @@ SettingsDialog::SettingsDialog(QWidget* parent)
 
 SettingsDialog::~SettingsDialog() = default;
 
-void SettingsDialog::initSettings(const QString& configName)
+void SettingsDialog::initSettings()
 {
-    m_configs->selectConfig(configName);
+    const auto configName = Settings::instance()->lastUsedEnvironment();
+    if (!configName.isEmpty()) {
+        m_configs->selectConfig(configName);
+    }
 }
 
 void SettingsDialog::initSettings(const QString &sysroot, const QString &appPath, const QString &extraLibPaths,

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -26,7 +26,7 @@ class SettingsDialog : public KPageDialog
 public:
     explicit SettingsDialog(QWidget* parent = nullptr);
     ~SettingsDialog();
-    void initSettings(const QString& configName);
+    void initSettings();
     void initSettings(const QString& sysroot, const QString& appPath, const QString& extraLibPaths,
                       const QString& debugPaths, const QString& kallsyms, const QString& arch, const QString& objdump);    
     QString sysroot() const;


### PR DESCRIPTION
let perfparser use `Settings::instance` to access sysroot, ...
removes the broken feature to open multiple windows and replaces it with a working one