### PR TITLE
improve eliding in the flamegraph

### DIFF
--- a/src/flamegraph.cpp
+++ b/src/flamegraph.cpp
@@ -42,6 +42,7 @@
 #include "models/filterandzoomstack.h"
 #include "resultsutil.h"
 #include "settings.h"
+#include "util.h"
 
 namespace {
 enum SearchMatchType
@@ -181,7 +182,7 @@ void FrameGraphicsItem::paint(QPainter* painter, const QStyleOptionGraphicsItem*
     const auto symbolText = symbol.isEmpty() ? QObject::tr("?? [%1]").arg(binary) : symbol;
     painter->drawText(margin + rect().x(), rect().y(), width, height,
                       Qt::AlignVCenter | Qt::AlignLeft | Qt::TextSingleLine,
-                      option->fontMetrics.elidedText(symbolText, Qt::ElideRight, width));
+                      Util::elideSymbol(symbolText, option->fontMetrics, width));
 
     if (m_searchMatch == NoMatch) {
         painter->setPen(oldPen);
@@ -598,7 +599,8 @@ FlameGraph::FlameGraph(QWidget* parent, Qt::WindowFlags flags)
     m_view->setScene(m_scene);
     m_view->viewport()->installEventFilter(this);
     m_view->viewport()->setMouseTracking(true);
-    m_view->setFont(QFont(QStringLiteral("monospace")));
+    // fix for  QTBUG-105237 view->setFont does not update fontMetrics only the rendered font
+    m_scene->setFont(QFont(QStringLiteral("monospace")));
 
     m_backButton = new QPushButton(this);
     m_backButton->setIcon(QIcon::fromTheme(QStringLiteral("go-previous")));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -57,6 +57,9 @@ QString collapseTemplate(const QString& str, int level)
         return false;
     };
 
+    // QLatin1String does not work with …
+    const auto elideString = QString::fromUtf8("<…");
+
     QString output;
     output.reserve(str.size());
     const auto operatorKeyword = QLatin1String("operator");
@@ -67,7 +70,7 @@ QString collapseTemplate(const QString& str, int level)
         if (c == QLatin1Char('<')) {
             depth++;
             if (depth == level) {
-                output.append(QLatin1String("<..."));
+                output.append(elideString);
             }
         } else if (c == QLatin1Char('>')) {
             depth--;

--- a/src/util.h
+++ b/src/util.h
@@ -13,6 +13,7 @@
 
 class QString;
 class QProcessEnvironment;
+class QFontMetrics;
 
 namespace Data {
 struct Symbol;
@@ -60,6 +61,8 @@ QString formatTooltip(int id, const Data::Symbol& symbol, const Data::Costs& sel
                       const Data::Costs& inclusiveCosts);
 QString formatTooltip(const Data::Symbol& symbol, const Data::ItemCost& itemCost, const Data::Costs& totalCosts);
 QString formatTooltip(const QString& location, const Data::LocationCost& cost, const Data::Costs& totalCosts);
+
+QString elideSymbol(const QString& symbolText, const QFontMetrics& metrics, int maxWidth);
 
 // the process environment including the custom AppImage-specific LD_LIBRARY_PATH
 // this is initialized on the first call and cached internally afterwards

--- a/tests/modeltests/tst_models.cpp
+++ b/tests/modeltests/tst_models.cpp
@@ -651,6 +651,41 @@ private slots:
 
         QCOMPARE(collapseTemplate(original, 1), collapsed);
     }
+
+    void testSymbolEliding_data()
+    {
+        QTest::addColumn<int>("maxWidth");
+        QTest::addColumn<QString>("elidedSymbol");
+
+        QTest::addRow("no eliding")
+            << 1500 << "asdf_namespace::foobar<asdf, yxcvyxcv>::blablub(someotherreallylongnames) const";
+        QTest::addRow("elide arguments")
+            << 1000 << "asdf_namespace::foobar<asdf, yxcvyxcv>::blablub(someotherreallylongn…) const";
+        QTest::addRow("elide templates") << 700 << "asdf_namespace::foobar<…>::blablub(…) const";
+        QTest::addRow("elide symbol") << 350 << "…obar<…>::blablub(…) const";
+    }
+
+    void testSymbolEliding()
+    {
+        const QFontMetrics metrics(QFont(QStringLiteral("monospace"), 10));
+
+        const QString testSymbol =
+            QStringLiteral("asdf_namespace::foobar<asdf, yxcvyxcv>::blablub(someotherreallylongnames) const");
+
+        QFETCH(int, maxWidth);
+        QFETCH(QString, elidedSymbol);
+
+        QCOMPARE(Util::elideSymbol(testSymbol, metrics, maxWidth), elidedSymbol);
+    }
+
+    void testSymbolElidingParanthese()
+    {
+        const QFontMetrics metrics(QFont(QStringLiteral("monospace"), 10));
+
+        const QString symbol = QStringLiteral("Foo<&bar::operator()>::asdf<XYZ>(blabla<&foo::operator(), ')', '('>)");
+
+        QCOMPARE(Util::elideSymbol(symbol, metrics, 700), "Foo<&bar::operator()>::asdf<XYZ>(blabla<&foo::opera…)");
+    }
 };
 
 HOTSPOT_GUITEST_MAIN(TestModels);

--- a/tests/modeltests/tst_models.cpp
+++ b/tests/modeltests/tst_models.cpp
@@ -616,31 +616,31 @@ private slots:
         QTest::addColumn<QString>("collapsed");
 
         QTest::addRow("operator<") << "Foo<Bar> operator< (Asdf<Xyz>);"
-                                   << "Foo<...> operator< (Asdf<...>);";
+                                   << "Foo<…> operator< (Asdf<…>);";
         QTest::addRow("operator>") << "Foo<Bar> operator> (Asdf<Xyz>);"
-                                   << "Foo<...> operator> (Asdf<...>);";
+                                   << "Foo<…> operator> (Asdf<…>);";
         QTest::addRow("operator<<") << "Foo<Bar> operator<< (Asdf<Xyz>);"
-                                    << "Foo<...> operator<< (Asdf<...>);";
+                                    << "Foo<…> operator<< (Asdf<…>);";
         QTest::addRow("operator>>") << "Foo<Bar> operator>> (Asdf<Xyz>);"
-                                    << "Foo<...> operator>> (Asdf<...>);";
+                                    << "Foo<…> operator>> (Asdf<…>);";
 
         QTest::addRow("operator <") << "Foo<Bar> operator < (Asdf<Xyz>);"
-                                    << "Foo<...> operator < (Asdf<...>);";
+                                    << "Foo<…> operator < (Asdf<…>);";
         QTest::addRow("operator   >") << "Foo<Bar> operator   > (Asdf<Xyz>);"
-                                      << "Foo<...> operator   > (Asdf<...>);";
+                                      << "Foo<…> operator   > (Asdf<…>);";
         QTest::addRow("operator <<") << "Foo<Bar> operator << (Asdf<Xyz>);"
-                                     << "Foo<...> operator << (Asdf<...>);";
+                                     << "Foo<…> operator << (Asdf<…>);";
         QTest::addRow("operator   >>") << "Foo<Bar> operator   >> (Asdf<Xyz>);"
-                                       << "Foo<...> operator   >> (Asdf<...>);";
+                                       << "Foo<…> operator   >> (Asdf<…>);";
 
         QTest::addRow("operator< 2") << "Foo<Bar<Xyz>> operator< (Asdf<Xyz>);"
-                                     << "Foo<...> operator< (Asdf<...>);";
+                                     << "Foo<…> operator< (Asdf<…>);";
         QTest::addRow("operator> 2") << "Foo<Bar<Xyz>> operator> (Asdf<Xyz>);"
-                                     << "Foo<...> operator> (Asdf<...>);";
+                                     << "Foo<…> operator> (Asdf<…>);";
         QTest::addRow("operator<< 2") << "Foo<Bar<Xyz>> operator<< (Asdf<Xyz>);"
-                                      << "Foo<...> operator<< (Asdf<...>);";
+                                      << "Foo<…> operator<< (Asdf<…>);";
         QTest::addRow("operator>> 2") << "Foo<Bar<Xyz>> operator>> (Asdf<Xyz>);"
-                                      << "Foo<...> operator>> (Asdf<...>);";
+                                      << "Foo<…> operator>> (Asdf<…>);";
     }
 
     void testCollapseTemplates()


### PR DESCRIPTION
in some cases the flamegraph contains only std::... and not the function
name.
This patch allows the user to change the eliding to ElideLeft so that
you can see the function name