### PR TITLE
Fix segfault in SourceCodeModel::headerData

### DIFF
--- a/src/models/codedelegate.cpp
+++ b/src/models/codedelegate.cpp
@@ -35,8 +35,8 @@ CodeDelegate::~CodeDelegate() = default;
 
 void CodeDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
 {
-    const auto& brush = painter->brush();
-    const auto& pen = painter->pen();
+    const auto brush = painter->brush();
+    const auto pen = painter->pen();
 
     painter->setPen(Qt::NoPen);
 

--- a/src/models/costdelegate.cpp
+++ b/src/models/costdelegate.cpp
@@ -36,8 +36,8 @@ void CostDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, 
     auto rect = option.rect;
     rect.setWidth(rect.width() * fraction);
 
-    const auto& brush = painter->brush();
-    const auto& pen = painter->pen();
+    const auto brush = painter->brush();
+    const auto pen = painter->pen();
 
     painter->setPen(Qt::NoPen);
 

--- a/src/models/disassemblymodel.cpp
+++ b/src/models/disassemblymodel.cpp
@@ -47,10 +47,14 @@ QModelIndex DisassemblyModel::findIndexWithOffset(int offset)
     return {};
 }
 
-void DisassemblyModel::setDisassembly(const DisassemblyOutput& disassemblyOutput)
+void DisassemblyModel::setDisassembly(const DisassemblyOutput& disassemblyOutput,
+                                      const Data::CallerCalleeResults& results)
 {
     beginResetModel();
+
     m_data = disassemblyOutput;
+    m_results = results;
+    m_numTypes = results.selfCosts.numTypes();
 
     QTextCursor cursor(m_document);
     for (const auto& it : disassemblyOutput.disassemblyLines) {
@@ -62,14 +66,6 @@ void DisassemblyModel::setDisassembly(const DisassemblyOutput& disassemblyOutput
 
     m_highlighter->setDefinitionForName(QStringLiteral("GNU Assembler"));
 
-    endResetModel();
-}
-
-void DisassemblyModel::setResults(const Data::CallerCalleeResults& results)
-{
-    beginResetModel();
-    m_results = results;
-    m_numTypes = results.selfCosts.numTypes();
     endResetModel();
 }
 

--- a/src/models/disassemblymodel.h
+++ b/src/models/disassemblymodel.h
@@ -25,8 +25,7 @@ public:
     explicit DisassemblyModel(QObject* parent = nullptr);
     ~DisassemblyModel();
 
-    void setDisassembly(const DisassemblyOutput& disassemblyOutput);
-    void setResults(const Data::CallerCalleeResults& results);
+    void setDisassembly(const DisassemblyOutput& disassemblyOutput, const Data::CallerCalleeResults& results);
 
     void clear();
     QModelIndex findIndexWithOffset(int offset);

--- a/src/models/sourcecodemodel.cpp
+++ b/src/models/sourcecodemodel.cpp
@@ -9,6 +9,7 @@
 
 #include <QDir>
 #include <QFile>
+#include <QScopeGuard>
 #include <QTextBlock>
 #include <QTextDocument>
 
@@ -31,10 +32,14 @@ void SourceCodeModel::clear()
     endResetModel();
 }
 
-void SourceCodeModel::setDisassembly(const DisassemblyOutput& disassemblyOutput)
+void SourceCodeModel::setDisassembly(const DisassemblyOutput& disassemblyOutput,
+                                     const Data::CallerCalleeResults& results)
 {
-    m_numLines = 0;
+    beginResetModel();
+    auto guard = qScopeGuard([this]() { endResetModel(); });
+
     m_numTypes = 0;
+    m_numLines = 0;
 
     if (disassemblyOutput.mainSourceFileName.isEmpty())
         return;
@@ -44,16 +49,13 @@ void SourceCodeModel::setDisassembly(const DisassemblyOutput& disassemblyOutput)
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
         return;
 
-    beginResetModel();
-
     int maxLineNumber = 0;
     int minLineNumber = INT_MAX;
 
     m_validLineNumbers.clear();
 
-    auto entry = m_callerCalleeResults.entry(disassemblyOutput.symbol);
     m_costs = {};
-    m_costs.initializeCostsFrom(m_callerCalleeResults.selfCosts);
+    m_costs.initializeCostsFrom(results.selfCosts);
 
     m_numTypes = m_costs.numTypes();
 
@@ -76,13 +78,15 @@ void SourceCodeModel::setDisassembly(const DisassemblyOutput& disassemblyOutput)
             minLineNumber = line.sourceCodeLine;
         }
 
-        auto it = entry.offsetMap.find(line.addr);
-        if (it != entry.offsetMap.end()) {
-            const auto& locationCost = it.value();
-            const auto& costLine = locationCost.selfCost;
-            const auto totalCost = m_callerCalleeResults.selfCosts.totalCosts();
+        const auto entry = results.entries.find(disassemblyOutput.symbol);
+        if (entry != results.entries.end()) {
+            const auto it = entry->offsetMap.find(line.addr);
+            if (it != entry->offsetMap.end()) {
+                const auto& locationCost = it.value();
+                const auto& costLine = locationCost.selfCost;
 
-            m_costs.add(line.sourceCodeLine, costLine);
+                m_costs.add(line.sourceCodeLine, costLine);
+            }
         }
 
         m_validLineNumbers.insert(line.sourceCodeLine);
@@ -99,8 +103,6 @@ void SourceCodeModel::setDisassembly(const DisassemblyOutput& disassemblyOutput)
     cursor.select(QTextCursor::SelectionType::LineUnderCursor);
     cursor.removeSelectedText();
     cursor.insertText(disassemblyOutput.symbol.prettySymbol);
-
-    endResetModel();
 }
 
 QVariant SourceCodeModel::headerData(int section, Qt::Orientation orientation, int role) const
@@ -193,11 +195,4 @@ int SourceCodeModel::lineForIndex(const QModelIndex& index) const
 void SourceCodeModel::setSysroot(const QString& sysroot)
 {
     m_sysroot = sysroot;
-}
-
-void SourceCodeModel::setCallerCalleeResults(const Data::CallerCalleeResults& results)
-{
-    beginResetModel();
-    m_callerCalleeResults = results;
-    endResetModel();
 }

--- a/src/models/sourcecodemodel.cpp
+++ b/src/models/sourcecodemodel.cpp
@@ -34,6 +34,7 @@ void SourceCodeModel::clear()
 void SourceCodeModel::setDisassembly(const DisassemblyOutput& disassemblyOutput)
 {
     m_numLines = 0;
+    m_numTypes = 0;
 
     if (disassemblyOutput.mainSourceFileName.isEmpty())
         return;
@@ -53,6 +54,8 @@ void SourceCodeModel::setDisassembly(const DisassemblyOutput& disassemblyOutput)
     auto entry = m_callerCalleeResults.entry(disassemblyOutput.symbol);
     m_costs = {};
     m_costs.initializeCostsFrom(m_callerCalleeResults.selfCosts);
+
+    m_numTypes = m_costs.numTypes();
 
     const auto sourceCode = QString::fromUtf8(file.readAll());
 
@@ -196,6 +199,5 @@ void SourceCodeModel::setCallerCalleeResults(const Data::CallerCalleeResults& re
 {
     beginResetModel();
     m_callerCalleeResults = results;
-    m_numTypes = results.selfCosts.numTypes();
     endResetModel();
 }

--- a/src/models/sourcecodemodel.h
+++ b/src/models/sourcecodemodel.h
@@ -28,7 +28,7 @@ public:
     ~SourceCodeModel();
 
     void clear();
-    void setDisassembly(const DisassemblyOutput& disassemblyOutput);
+    void setDisassembly(const DisassemblyOutput& disassemblyOutput, const Data::CallerCalleeResults& results);
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
@@ -57,14 +57,12 @@ public:
 public slots:
     void updateHighlighting(int line);
     void setSysroot(const QString& sysroot);
-    void setCallerCalleeResults(const Data::CallerCalleeResults& results);
 
 private:
     QString m_sysroot;
     QSet<int> m_validLineNumbers;
     QTextDocument* m_document = nullptr;
     Highlighter* m_highlighter = nullptr;
-    Data::CallerCalleeResults m_callerCalleeResults;
     Data::Costs m_costs;
     int m_numTypes = 0;
     int m_lineOffset = 0;

--- a/src/resultsdisassemblypage.cpp
+++ b/src/resultsdisassemblypage.cpp
@@ -175,8 +175,8 @@ void ResultsDisassemblyPage::showDisassembly(const DisassemblyOutput& disassembl
 
     ui->errorMessage->hide();
 
-    m_disassemblyModel->setDisassembly(disassemblyOutput);
-    m_sourceCodeModel->setDisassembly(disassemblyOutput);
+    m_disassemblyModel->setDisassembly(disassemblyOutput, m_callerCalleeResults);
+    m_sourceCodeModel->setDisassembly(disassemblyOutput, m_callerCalleeResults);
 
     setupAsmViewModel();
 }
@@ -189,8 +189,6 @@ void ResultsDisassemblyPage::setSymbol(const Data::Symbol& symbol)
 void ResultsDisassemblyPage::setCostsMap(const Data::CallerCalleeResults& callerCalleeResults)
 {
     m_callerCalleeResults = callerCalleeResults;
-    m_disassemblyModel->setResults(m_callerCalleeResults);
-    m_sourceCodeModel->setCallerCalleeResults(m_callerCalleeResults);
 }
 
 void ResultsDisassemblyPage::setObjdump(const QString& objdump)

--- a/tests/modeltests/tst_models.cpp
+++ b/tests/modeltests/tst_models.cpp
@@ -342,7 +342,7 @@ private slots:
         QCOMPARE(model.rowCount(), disassemblyOutput.disassemblyLines.size());
     }
 
-    void testSourceCodeModel_data()
+    void testSourceCodeModelNoFileName_data()
     {
         QTest::addColumn<Data::Symbol>("symbol");
         Data::Symbol symbol = {"__cos_fma",
@@ -357,7 +357,7 @@ private slots:
         QTest::newRow("curSymbol") << symbol;
     }
 
-    void testSourceCodeModel()
+    void testSourceCodeModelNoFileName()
     {
         QFETCH(Data::Symbol, symbol);
 

--- a/tests/modeltests/tst_models.cpp
+++ b/tests/modeltests/tst_models.cpp
@@ -15,6 +15,7 @@
 
 #include <models/disassemblymodel.h>
 #include <models/eventmodel.h>
+#include <models/sourcecodemodel.h>
 
 namespace {
 Data::BottomUpResults buildBottomUpTree(const QByteArray& stacks)
@@ -330,14 +331,54 @@ private slots:
         locationCost.selfCost[0] += 200;
 
         DisassemblyModel model;
-        QAbstractItemModelTester tester(&model);
-        model.setResults(results);
-        QCOMPARE(model.columnCount(), DisassemblyModel::COLUMN_COUNT + results.selfCosts.numTypes());
-        QCOMPARE(model.rowCount(), 0); // no disassembly data yet
+
+        // no disassembly data yet
+        QCOMPARE(model.columnCount(), DisassemblyModel::COLUMN_COUNT);
+        QCOMPARE(model.rowCount(), 0);
 
         DisassemblyOutput disassemblyOutput = DisassemblyOutput::disassemble("objdump", "x86_64", symbol);
-        model.setDisassembly(disassemblyOutput);
+        model.setDisassembly(disassemblyOutput, results);
+        QCOMPARE(model.columnCount(), DisassemblyModel::COLUMN_COUNT + results.selfCosts.numTypes());
         QCOMPARE(model.rowCount(), disassemblyOutput.disassemblyLines.size());
+    }
+
+    void testSourceCodeModel_data()
+    {
+        QTest::addColumn<Data::Symbol>("symbol");
+        Data::Symbol symbol = {"__cos_fma",
+                               4294544,
+                               2093,
+                               "vector_static_gcc/vector_static_gcc_v9.1.0",
+                               "/home/milian/projects/kdab/rnd/hotspot/3rdparty/perfparser/tests/auto/perfdata/"
+                               "vector_static_gcc/vector_static_gcc_v9.1.0",
+                               "/home/milian/projects/kdab/rnd/hotspot/3rdparty/perfparser/tests/auto/perfdata/"
+                               "vector_static_gcc/vector_static_gcc_v9.1.0"};
+
+        QTest::newRow("curSymbol") << symbol;
+    }
+
+    void testSourceCodeModel()
+    {
+        QFETCH(Data::Symbol, symbol);
+
+        const auto actualBinaryFile = QFINDTESTDATA(symbol.binary);
+        symbol.actualPath = actualBinaryFile;
+
+        const auto tree = generateTree1();
+
+        Data::CallerCalleeResults results;
+        Data::callerCalleesFromBottomUpData(tree, &results);
+
+        SourceCodeModel model;
+        QCOMPARE(model.columnCount(), SourceCodeModel::COLUMN_COUNT);
+        QCOMPARE(model.rowCount(), 0);
+
+        DisassemblyOutput disassemblyOutput = DisassemblyOutput::disassemble("objdump", "x86_64", symbol);
+        model.setDisassembly(disassemblyOutput, results);
+
+        // no source file name
+        QCOMPARE(model.columnCount(), SourceCodeModel::COLUMN_COUNT);
+        QCOMPARE(model.rowCount(), 0);
     }
 
     void testEventModel()


### PR DESCRIPTION
resolves #406 

I tracked the issue down to the:
- `SourceCodeModel::setCallerCalleeResults` setting `m_numTypes` to `1`
- file fails to open in `SourceCodeModel::setDisassembly` and we return early
- since we return early we never call `m_costs.initializeCostsFrom(m_callerCalleeResults.selfCosts);`
- therefore `m_costs.m_typeNames` is empty
- call to `return m_costs.typeName(section - COLUMN_COUNT);` segfaults
