### PR TITLE
fix crash in SourceCodeModel::headerData

### DIFF
--- a/src/models/sourcecodemodel.cpp
+++ b/src/models/sourcecodemodel.cpp
@@ -35,6 +35,10 @@ void SourceCodeModel::setDisassembly(const DisassemblyOutput& disassemblyOutput)
 {
     m_numLines = 0;
 
+    // initilize costs to prevent crash in headerData if costs is empty
+    m_costs = {};
+    m_costs.initializeCostsFrom(m_callerCalleeResults.selfCosts);
+
     if (disassemblyOutput.mainSourceFileName.isEmpty())
         return;
 
@@ -51,8 +55,6 @@ void SourceCodeModel::setDisassembly(const DisassemblyOutput& disassemblyOutput)
     m_validLineNumbers.clear();
 
     auto entry = m_callerCalleeResults.entry(disassemblyOutput.symbol);
-    m_costs = {};
-    m_costs.initializeCostsFrom(m_callerCalleeResults.selfCosts);
 
     const auto sourceCode = QString::fromUtf8(file.readAll());
 


### PR DESCRIPTION
m_costs was not initialized if no source code was found this caused a crash in headerData when m_costs.typeNames[0] was accessed

fixes: #406