### PR TITLE
output full objdump command on empty output

### DIFF
--- a/src/models/disassemblyoutput.cpp
+++ b/src/models/disassemblyoutput.cpp
@@ -175,7 +175,8 @@ DisassemblyOutput DisassemblyOutput::disassemble(const QString& objdump, const Q
     }
 
     if (output.isEmpty()) {
-        disassemblyOutput.errorMessage += QApplication::tr("Empty output of command %1").arg(objdump);
+        disassemblyOutput.errorMessage +=
+            QApplication::tr("Empty output of command %1 %2").arg(objdump, arguments.join(QLatin1Char(' ')));
     }
 
     const auto objdumpOutput = objdumpParse(output);


### PR DESCRIPTION
currently we get a warning / note with no details; adding those allows to execute it outside of hotspot and check for possible issues with that invocation

fair warning: this change is untested (other than CI passing); and if there's a testcase for the message it needs to be adjusted