### PR TITLE
use messageType warning for disassembly issues

### DIFF
--- a/src/resultsdisassemblypage.ui
+++ b/src/resultsdisassemblypage.ui
@@ -24,7 +24,11 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="KMessageWidget" name="errorMessage"/>
+    <widget class="KMessageWidget" name="errorMessage">
+     <property name="messageType">
+      <enum>KMessageWidget::Warning</enum>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="KSqueezedTextLabel" name="filenameLabel">


### PR DESCRIPTION
making it identical to resultspageui where it was added in 002d0e1b325b738dfbe48c65c9f97f0106ee8b81

again: untested (just verified that the result is valid XML)

Note: the widget in resultspageui is animated on show, which isn't the case for resultsdisassemblypage (at least with x-forwarding the animation stutters, so I like the one without more); whatever "the way it should be done" is - it is likely a good idea to use the same approach for both widgets.