### PR TITLE
Make libdebugd check in perfparser.cmake take into account library status

### DIFF
--- a/3rdparty/perfparser.cmake
+++ b/3rdparty/perfparser.cmake
@@ -44,7 +44,7 @@ if (Zstd_FOUND)
     target_compile_definitions(libhotspot-perfparser PUBLIC HAVE_ZSTD=1)
 endif()
 
-if (HAVE_DWFL_GET_DEBUGINFOD_CLIENT)
+if (HAVE_DWFL_GET_DEBUGINFOD_CLIENT AND LIBDEBUGINFOD_LIBRARIES)
     target_link_libraries(libhotspot-perfparser PRIVATE ${LIBDEBUGINFOD_LIBRARIES})
     target_compile_definitions(libhotspot-perfparser PRIVATE HAVE_DWFL_GET_DEBUGINFOD_CLIENT=1)
 endif()


### PR DESCRIPTION
On my computer I have libdebugd disabled. However it seems like it still finds some symbols from it in `libdwfl.h`. This would make the configure step fail as `LIBDEBUGINFOD_LIBRARIES` would be set to `NOT-FOUND` but it would still try to use it.

I'm guessing having the `HAVE_DWFL_GET_DEBUGINFOD_CLIENT` is there to ensure that the whole pipeline has libdebugd support. However it also needs to check if the libraries are found as it is not certain that the libdebugd libraries are available even if `HAVE_DWFL_GET_DEBUGINFOD_CLIENT` is true.