### PR TITLE
add search function for source code was: cache source code in vector for easier access in search function

### DIFF
--- a/src/models/disassemblymodel.cpp
+++ b/src/models/disassemblymodel.cpp
@@ -14,6 +14,7 @@
 #include "hotspot-config.h"
 
 #include "highlighter.hpp"
+#include "search.h"
 #include "sourcecodemodel.h"
 
 DisassemblyModel::DisassemblyModel(KSyntaxHighlighting::Repository* repository, QObject* parent)
@@ -221,4 +222,20 @@ QModelIndex DisassemblyModel::indexForFileLine(const Data::FileLine& fileLine) c
     if (bestMatch == -1)
         return {};
     return index(bestMatch, 0);
+}
+
+void DisassemblyModel::find(const QString& search, Direction direction, int offset)
+{
+    auto searchFunc = [&search](const DisassemblyOutput::DisassemblyLine& line) {
+        return line.disassembly.indexOf(search, 0, Qt::CaseInsensitive) != -1;
+    };
+
+    int resultIndex = ::search(
+        m_data.disassemblyLines, searchFunc, [this] { emit resultFound({}); }, direction, offset);
+
+    if (resultIndex >= 0) {
+        emit resultFound(createIndex(resultIndex, DisassemblyColumn));
+    } else {
+        emit resultFound({});
+    }
 }

--- a/src/models/disassemblymodel.h
+++ b/src/models/disassemblymodel.h
@@ -23,6 +23,8 @@ class Definition;
 class Repository;
 }
 
+enum class Direction;
+
 class DisassemblyModel : public QAbstractTableModel
 {
     Q_OBJECT
@@ -67,8 +69,13 @@ public:
         SyntaxHighlightRole,
     };
 
+signals:
+    void resultFound(QModelIndex index);
+    void searchEndReached();
+
 public slots:
     void updateHighlighting(int line);
+    void find(const QString& search, Direction direction, int offset);
 
 private:
     QTextDocument* m_document;

--- a/src/models/search.h
+++ b/src/models/search.h
@@ -1,0 +1,50 @@
+/*
+    SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
+    SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#pragma once
+
+#include <QVector>
+
+enum class Direction
+{
+    Forward,
+    Backward
+};
+
+template<typename entry, typename SearchFunc, typename EndReached>
+int search(QVector<entry> source, SearchFunc&& searchFunc, EndReached&& endReached, Direction direction, int offset)
+{
+    if (offset > source.size() || offset < 0) {
+        offset = 0;
+    }
+
+    auto start = direction == Direction::Forward
+        ? (source.begin() + offset)
+        : (source.end() - (source.size() - offset - 1)); // 1 one due to offset of the reverse iterator
+
+    auto it = direction == Direction::Forward
+        ? std::find_if(start, source.end(), searchFunc)
+        : (std::find_if(std::make_reverse_iterator(start), source.rend(), searchFunc) + 1).base();
+
+    // it is less than source.begin() if the backward search ends at source.rend()
+    if (it >= source.begin() && it < source.end()) {
+        auto distance = std::distance(source.begin(), it);
+        return distance;
+    }
+
+    it = direction == Direction::Forward
+        ? std::find_if(source.begin(), start, searchFunc)
+        : (std::find_if(source.rbegin(), std::make_reverse_iterator(start), searchFunc) + 1).base();
+
+    if (it != source.end()) {
+        auto distance = std::distance(source.begin(), it);
+        endReached();
+        return distance;
+    }
+
+    return -1;
+}

--- a/src/models/sourcecodemodel.cpp
+++ b/src/models/sourcecodemodel.cpp
@@ -69,6 +69,8 @@ void SourceCodeModel::setDisassembly(const DisassemblyOutput& disassemblyOutput,
 
     m_mainSourceFileName = disassemblyOutput.mainSourceFileName;
 
+    const auto entry = results.entries.find(disassemblyOutput.symbol);
+
     for (const auto& line : disassemblyOutput.disassemblyLines) {
         if (line.fileLine.line == 0 || line.fileLine.file != disassemblyOutput.mainSourceFileName) {
             continue;
@@ -84,7 +86,6 @@ void SourceCodeModel::setDisassembly(const DisassemblyOutput& disassemblyOutput,
         if (m_validLineNumbers.contains(line.fileLine.line))
             continue;
 
-        const auto entry = results.entries.find(disassemblyOutput.symbol);
         if (entry != results.entries.end()) {
             const auto it = entry->sourceMap.find(line.fileLine);
             if (it != entry->sourceMap.end()) {

--- a/src/models/sourcecodemodel.h
+++ b/src/models/sourcecodemodel.h
@@ -23,6 +23,12 @@ class Repository;
 class Definition;
 }
 
+struct SourceCodeLine
+{
+    QString text;
+    QTextLine line;
+};
+
 Q_DECLARE_METATYPE(QTextLine)
 
 class SourceCodeModel : public QAbstractTableModel
@@ -74,12 +80,12 @@ private:
     QString m_sysroot;
     QSet<int> m_validLineNumbers;
     QTextDocument* m_document = nullptr;
+    QVector<SourceCodeLine> m_sourceCodeLines;
     Highlighter* m_highlighter = nullptr;
     Data::Costs m_selfCosts;
     Data::Costs m_inclusiveCosts;
     QString m_mainSourceFileName;
     QString m_prettySymbol;
-    int m_lineOffset = 0;
     int m_startLine = 0;
     int m_numLines = 0;
     int m_highlightLine = 0;

--- a/src/models/sourcecodemodel.h
+++ b/src/models/sourcecodemodel.h
@@ -28,6 +28,9 @@ struct SourceCodeLine
     QString text;
     QTextLine line;
 };
+Q_DECLARE_TYPEINFO(SourceCodeLine, Q_MOVABLE_TYPE);
+
+enum class Direction;
 
 Q_DECLARE_METATYPE(QTextLine)
 
@@ -72,9 +75,15 @@ public:
         FileLineRole,
     };
 
+signals:
+    void resultFound(QModelIndex index);
+    void searchEndReached();
+
 public slots:
     void updateHighlighting(int line);
     void setSysroot(const QString& sysroot);
+
+    void find(const QString& search, Direction direction, int offset);
 
 private:
     QString m_sysroot;

--- a/src/resultsdisassemblypage.cpp
+++ b/src/resultsdisassemblypage.cpp
@@ -23,7 +23,9 @@
 #include <QTemporaryFile>
 #include <QTextStream>
 
+#include <KColorScheme>
 #include <KRecursiveFilterProxyModel>
+#include <KStandardAction>
 
 #include "parsers/perf/perfparser.h"
 #include "resultsutil.h"
@@ -42,10 +44,20 @@
 #include "models/costdelegate.h"
 #include "models/disassemblymodel.h"
 #include "models/hashmodel.h"
+#include "models/search.h"
 #include "models/sourcecodemodel.h"
 #include "models/topproxy.h"
 #include "models/treemodel.h"
 #include "settings.h"
+
+namespace {
+template<typename ModelType, typename ResultFound, typename EndReached>
+void connectModel(ModelType* model, ResultFound resultFound, EndReached endReached)
+{
+    QObject::connect(model, &ModelType::resultFound, model, resultFound);
+    QObject::connect(model, &ModelType::searchEndReached, model, endReached);
+}
+}
 
 ResultsDisassemblyPage::ResultsDisassemblyPage(CostContextMenu* costContextMenu, QWidget* parent)
     : QWidget(parent)
@@ -170,6 +182,76 @@ ResultsDisassemblyPage::ResultsDisassemblyPage(CostContextMenu* costContextMenu,
 
         showDisassembly();
     });
+
+    ui->searchEndWidget->hide();
+    ui->disasmEndReachedWidget->hide();
+
+    auto setupSearchShortcuts = [this](QPushButton* search, QPushButton* next, QPushButton* prev, QPushButton* close,
+                                       QWidget* searchWidget, QLineEdit* edit, QAbstractItemView* view,
+                                       KMessageWidget* endReached, auto* model, int additionalRows) {
+        searchWidget->hide();
+
+        auto actions = new QActionGroup(view);
+
+        auto findAction = KStandardAction::find(
+            this,
+            [searchWidget, edit] {
+                searchWidget->show();
+                edit->setFocus();
+            },
+            actions);
+        findAction->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
+        view->addAction(findAction);
+
+        auto searchNext = [this, model, edit, additionalRows] {
+            int offset = m_currentSearchIndex.isValid() ? m_currentSearchIndex.row() - additionalRows + 1 : 0;
+            model->find(edit->text(), Direction::Forward, offset);
+        };
+
+        auto searchPrev = [this, model, edit, additionalRows] {
+            int offset = m_currentSearchIndex.isValid() ? m_currentSearchIndex.row() - additionalRows - 1 : 0;
+
+            model->find(edit->text(), Direction::Backward, offset);
+        };
+
+        auto findNextAction = KStandardAction::findNext(this, searchNext, actions);
+        findNextAction->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
+        searchWidget->addAction(findNextAction);
+        auto findPrevAction = KStandardAction::findPrev(this, searchPrev, actions);
+        findPrevAction->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
+        searchWidget->addAction(findPrevAction);
+
+        connect(edit, &QLineEdit::returnPressed, findNextAction, &QAction::trigger);
+        connect(next, &QPushButton::clicked, findNextAction, &QAction::trigger);
+        connect(prev, &QPushButton::clicked, findPrevAction, &QAction::trigger);
+
+        connect(search, &QPushButton::clicked, findAction, &QAction::trigger);
+        connect(close, &QPushButton::clicked, this, [searchWidget] { searchWidget->hide(); });
+
+        KColorScheme colorScheme;
+
+        connectModel(
+            model,
+            [this, edit, view, colorScheme](const QModelIndex& index) {
+                auto palette = edit->palette();
+                m_currentSearchIndex = index;
+                palette.setBrush(QPalette::Text,
+                                 index.isValid() ? colorScheme.foreground()
+                                                 : colorScheme.foreground(KColorScheme::NegativeText));
+                edit->setPalette(palette);
+                view->setCurrentIndex(index);
+
+                if (!index.isValid())
+                    view->clearSelection();
+            },
+            [endReached] { endReached->show(); });
+    };
+
+    setupSearchShortcuts(ui->searchButton, ui->nextResult, ui->prevResult, ui->closeButton, ui->searchWidget,
+                         ui->searchEdit, ui->sourceCodeView, ui->searchEndWidget, m_sourceCodeModel, 1);
+    setupSearchShortcuts(ui->disasmSearchButton, ui->disasmNextButton, ui->disasmPrevButton, ui->disasmCloseButton,
+                         ui->disasmSearchWidget, ui->disasmSearchEdit, ui->assemblyView, ui->disasmEndReachedWidget,
+                         m_disassemblyModel, 0);
 
 #if KF5SyntaxHighlighting_FOUND
     QStringList schemes;
@@ -310,17 +392,18 @@ void ResultsDisassemblyPage::showDisassembly(const DisassemblyOutput& disassembl
 
     ResultsUtil::hideEmptyColumns(m_callerCalleeResults.selfCosts, ui->assemblyView, DisassemblyModel::COLUMN_COUNT);
 
-    ResultsUtil::hideEmptyColumns(m_callerCalleeResults.selfCosts, ui->sourceCodeView,
-                                  SourceCodeModel::COLUMN_COUNT);
+    ResultsUtil::hideEmptyColumns(m_callerCalleeResults.selfCosts, ui->sourceCodeView, SourceCodeModel::COLUMN_COUNT);
 
     ResultsUtil::hideEmptyColumns(m_callerCalleeResults.inclusiveCosts, ui->sourceCodeView,
                                   SourceCodeModel::COLUMN_COUNT + m_callerCalleeResults.selfCosts.numTypes());
 
     // hide self cost for tracepoints in assembly view, this is basically always zero
-    ResultsUtil::hideTracepointColumns(m_callerCalleeResults.selfCosts, ui->assemblyView, DisassemblyModel::COLUMN_COUNT);
+    ResultsUtil::hideTracepointColumns(m_callerCalleeResults.selfCosts, ui->assemblyView,
+                                       DisassemblyModel::COLUMN_COUNT);
 
     // hide self cost for tracepoints - only show inclusive times instead here
-    ResultsUtil::hideTracepointColumns(m_callerCalleeResults.selfCosts, ui->sourceCodeView, SourceCodeModel::COLUMN_COUNT);
+    ResultsUtil::hideTracepointColumns(m_callerCalleeResults.selfCosts, ui->sourceCodeView,
+                                       SourceCodeModel::COLUMN_COUNT);
 
     setupAsmViewModel();
 }

--- a/src/resultsdisassemblypage.h
+++ b/src/resultsdisassemblypage.h
@@ -70,6 +70,7 @@ private:
     // Model
     DisassemblyModel* m_disassemblyModel;
     SourceCodeModel* m_sourceCodeModel;
+    QModelIndex m_currentSearchIndex;
     // Architecture
     QString m_arch;
     // Objdump binary name

--- a/src/resultsdisassemblypage.ui
+++ b/src/resultsdisassemblypage.ui
@@ -113,196 +113,328 @@
     </widget>
    </item>
    <item>
-     <widget class="QSplitter" name="widget">
+    <widget class="QSplitter" name="widget">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QWidget" name="widget_2" native="true">
-        <layout class="QVBoxLayout" name="verticalLayout_4">
-         <property name="spacing">
-          <number>0</number>
+     <widget class="QWidget" name="sourceCodeWidget" native="true">
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="KMessageWidget" name="searchEndWidget">
+         <property name="text">
+          <string>Search reached the end</string>
          </property>
-         <property name="leftMargin">
-          <number>0</number>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTreeView" name="sourceCodeView">
+         <property name="alternatingRowColors">
+          <bool>true</bool>
          </property>
-         <property name="topMargin">
-          <number>0</number>
+         <property name="rootIsDecorated">
+          <bool>false</bool>
          </property>
-         <property name="rightMargin">
-          <number>0</number>
+         <property name="uniformRowHeights">
+          <bool>true</bool>
          </property>
-         <property name="bottomMargin">
-          <number>0</number>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="searchWidget" native="true">
+         <property name="enabled">
+          <bool>true</bool>
          </property>
-         <item>
-          <widget class="QTreeView" name="sourceCodeView">
-           <property name="alternatingRowColors">
-            <bool>true</bool>
-           </property>
-           <property name="rootIsDecorated">
-            <bool>false</bool>
-           </property>
-           <property name="uniformRowHeights">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QWidget" name="customSourceCodeHighlighting" native="true">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
-            <property name="spacing">
-             <number>0</number>
+         <layout class="QHBoxLayout" name="horizontalLayout_8">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Search:</string>
             </property>
-            <property name="leftMargin">
-             <number>0</number>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="searchEdit"/>
+          </item>
+          <item>
+           <widget class="QPushButton" name="nextResult">
+            <property name="icon">
+             <iconset theme="arrow-down">
+              <normaloff>.</normaloff>.</iconset>
             </property>
-            <property name="topMargin">
-             <number>0</number>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="prevResult">
+            <property name="icon">
+             <iconset theme="arrow-up">
+              <normaloff>.</normaloff>.</iconset>
             </property>
-            <property name="rightMargin">
-             <number>0</number>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="closeButton">
+            <property name="text">
+             <string/>
             </property>
-            <property name="bottomMargin">
-             <number>0</number>
+            <property name="icon">
+             <iconset theme="dialog-close">
+              <normaloff>.</normaloff>.</iconset>
             </property>
-            <item>
-             <widget class="QLabel" name="label">
-              <property name="text">
-               <string>Syntax Highlighting:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QComboBox" name="sourceCodeComboBox">
-              <property name="editable">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-
-          <widget class="QWidget" name="customAssemblyHighlighting" native="true">
-           <layout class="QVBoxLayout" name="verticalLayout_2">
-            <property name="spacing">
-             <number>0</number>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="customSourceCodeHighlighting" native="true">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Syntax Highlighting:</string>
             </property>
-            <property name="leftMargin">
-             <number>0</number>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="sourceCodeComboBox">
+            <property name="editable">
+             <bool>true</bool>
             </property>
-            <property name="topMargin">
-             <number>0</number>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="searchButton">
+            <property name="icon">
+             <iconset theme="search">
+              <normaloff>.</normaloff>.</iconset>
             </property>
-            <property name="rightMargin">
-             <number>0</number>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
             </property>
-            <property name="bottomMargin">
-             <number>0</number>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
             </property>
-            <item>
-             <widget class="KMessageWidget" name="symbolNotFound"/>
-            </item>
-            <item>
-             <widget class="QTreeView" name="assemblyView">
-              <property name="alternatingRowColors">
-               <bool>true</bool>
-              </property>
-              <property name="rootIsDecorated">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QWidget" name="widget_5" native="true">
-              <layout class="QHBoxLayout" name="horizontalLayout_6">
-               <property name="spacing">
-                <number>0</number>
-               </property>
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
-               <item>
-                <widget class="QLabel" name="label_2">
-                 <property name="text">
-                  <string>Syntax Highlighting:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QComboBox" name="assemblyComboBox">
-                 <property name="editable">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer_2">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-
-      </item>
-     </layout>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="disassemblyWidget" native="true">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="KMessageWidget" name="symbolNotFound"/>
+       </item>
+       <item>
+        <widget class="KMessageWidget" name="disasmEndReachedWidget">
+         <property name="text">
+          <string>Search reached the end</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTreeView" name="assemblyView">
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="rootIsDecorated">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="disasmSearchWidget" native="true">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_7">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Search:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="disasmSearchEdit"/>
+          </item>
+          <item>
+           <widget class="QPushButton" name="disasmNextButton">
+            <property name="icon">
+             <iconset theme="arrow-down">
+              <normaloff>.</normaloff>.</iconset>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="disasmPrevButton">
+            <property name="icon">
+             <iconset theme="arrow-up">
+              <normaloff>.</normaloff>.</iconset>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="disasmCloseButton">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="icon">
+             <iconset theme="dialog-close">
+              <normaloff>.</normaloff>.</iconset>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="customAssemblyHighlighting" native="true">
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Syntax Highlighting:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="assemblyComboBox">
+            <property name="editable">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="disasmSearchButton">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="icon">
+             <iconset theme="search">
+              <normaloff>.</normaloff>.</iconset>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
I updated the SourceCodeModel to only include the function that is disassembled. Until now the whole file was included which wasted a lot of performance since KSyntaxHighlighter was run on the whole file.