### PR TITLE
Set source path

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,7 @@ set(HOTSPOT_SRCS
     callgraphwidget.ui
     callgraphsettingspage.ui
     frequencypage.ui
+    sourcepathsettings.ui
     # resources:
     resources.qrc
 )

--- a/src/models/disassemblyoutput.h
+++ b/src/models/disassemblyoutput.h
@@ -41,6 +41,10 @@ struct DisassemblyOutput
     }
 
     static DisassemblyOutput disassemble(const QString& objdump, const QString& arch, const QStringList& debugPaths,
-                                         const QStringList& extraLibPaths, const Data::Symbol& symbol);
+                                         const QStringList& extraLibPaths, const QStringList& sourceCodePaths,
+                                         const QString& sysroot, const Data::Symbol& symbol);
 };
+
+QString findSourceCodeFile(const QString& originalPath, const QStringList& sourceCodePaths, const QString& sysroot);
+
 Q_DECLARE_TYPEINFO(DisassemblyOutput::DisassemblyLine, Q_MOVABLE_TYPE);

--- a/src/resultscallercalleepage.cpp
+++ b/src/resultscallercalleepage.cpp
@@ -22,6 +22,7 @@
 #include "models/callercalleemodel.h"
 #include "models/callercalleeproxy.h"
 #include "models/costdelegate.h"
+#include "models/disassemblyoutput.h"
 #include "models/filterandzoomstack.h"
 #include "models/hashmodel.h"
 #include "models/treemodel.h"
@@ -281,7 +282,10 @@ void ResultsCallerCalleePage::openEditor(const Data::Symbol& symbol)
     auto it = std::find_if(map.keyBegin(), map.keyEnd(), [&symbol, this](const Data::FileLine& fileLine) {
         const auto location = toSourceMapLocation(fileLine, symbol);
         if (location) {
-            emit navigateToCode(location.path, location.lineNumber, 0);
+            auto settings = Settings::instance();
+            auto remappedSourceFile =
+                findSourceCodeFile(location.path, settings->sourceCodePaths(), settings->sysroot());
+            emit navigateToCode(remappedSourceFile, location.lineNumber, 0);
             return true;
         }
         return false;

--- a/src/resultsdisassemblypage.cpp
+++ b/src/resultsdisassemblypage.cpp
@@ -272,7 +272,8 @@ void ResultsDisassemblyPage::showDisassembly()
     const auto colon = QLatin1Char(':');
 
     showDisassembly(DisassemblyOutput::disassemble(objdump(), m_arch, settings->debugPaths().split(colon),
-                                                   settings->extraLibPaths().split(colon), curSymbol));
+                                                   settings->extraLibPaths().split(colon), settings->sourceCodePaths(),
+                                                   settings->sysroot(), curSymbol));
 }
 
 void ResultsDisassemblyPage::showDisassembly(const DisassemblyOutput& disassemblyOutput)

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -185,6 +185,10 @@ void Settings::loadFromFile()
         sharedConfig->group("PathSettings").writeEntry("userPaths", this->userPaths());
         sharedConfig->group("PathSettings").writeEntry("systemPaths", this->systemPaths());
     });
+    m_sourceCodePaths = sharedConfig->group("PathSettings").readEntry("sourceCodePaths", QStringList());
+    connect(this, &Settings::sourceCodePathsChanged, this, [sharedConfig](const QStringList& paths) {
+        sharedConfig->group("PathSettings").writeEntry("sourceCodePaths", paths);
+    });
 
     // fix build error in app image build
     const auto colorScheme = KColorScheme(QPalette::Normal, KColorScheme::View, sharedConfig);
@@ -221,4 +225,12 @@ void Settings::loadFromFile()
     connect(this, &Settings::lastUsedEnvironmentChanged, this, [sharedConfig](const QString& envName) {
         sharedConfig->group("PerfPaths").writeEntry("lastUsed", envName);
     });
+}
+
+void Settings::setSourceCodePaths(const QStringList& paths)
+{
+    if (m_sourceCodePaths != paths) {
+        m_sourceCodePaths = paths;
+        emit sourceCodePathsChanged(m_sourceCodePaths);
+    }
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -139,6 +139,11 @@ public:
         return m_lastUsedEnvironment;
     }
 
+    QStringList sourceCodePaths() const
+    {
+        return m_sourceCodePaths;
+    }
+
     void loadFromFile();
 
 signals:
@@ -158,6 +163,7 @@ signals:
     void objdumpChanged(const QString& objdump);
     void callgraphChanged();
     void lastUsedEnvironmentChanged(const QString& envName);
+    void sourceCodePathsChanged(const QStringList& paths);
 
 public slots:
     void setPrettifySymbols(bool prettifySymbols);
@@ -178,6 +184,7 @@ public slots:
     void setCallgraphColors(const QColor& active, const QColor& inactive);
     void setCostAggregation(Settings::CostAggregation costAggregation);
     void setLastUsedEnvironment(const QString& envName);
+    void setSourceCodePaths(const QStringList& paths);
 
 private:
     Settings() = default;
@@ -191,6 +198,7 @@ private:
     QStringList m_userPaths;
     QStringList m_systemPaths;
     QStringList m_debuginfodUrls;
+    QStringList m_sourceCodePaths;
 
     QString m_sysroot;
     QString m_kallsyms;

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -17,6 +17,7 @@ class UnwindSettingsPage;
 class FlamegraphSettingsPage;
 class DebuginfodPage;
 class CallgraphSettingsPage;
+class SourcePathSettingsPage;
 }
 
 class MultiConfigWidget;
@@ -46,10 +47,12 @@ private:
     void addFlamegraphPage();
     void addDebuginfodPage();
     void addCallgraphPage();
+    void addSourcePathPage();
 
     std::unique_ptr<Ui::UnwindSettingsPage> unwindPage;
     std::unique_ptr<Ui::FlamegraphSettingsPage> flamegraphPage;
     std::unique_ptr<Ui::DebuginfodPage> debuginfodPage;
+    std::unique_ptr<Ui::SourcePathSettingsPage> sourcePathPage;
     std::unique_ptr<Ui::CallgraphSettingsPage> callgraphPage;
     MultiConfigWidget* m_configs;
 };

--- a/src/sourcepathsettings.ui
+++ b/src/sourcepathsettings.ui
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SourcePathSettingsPage</class>
+ <widget class="QWidget" name="SourcePathSettingsPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>240</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <property name="horizontalSpacing">
+    <number>0</number>
+   </property>
+   <property name="verticalSpacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Source Code Search Paths:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="KEditListWidget" name="sourcePaths">
+     <property name="buttons">
+      <set>KEditListWidget::All</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>KEditListWidget</class>
+   <extends>QWidget</extends>
+   <header>keditlistwidget.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/tests/modeltests/tst_models.cpp
+++ b/tests/modeltests/tst_models.cpp
@@ -354,7 +354,7 @@ private slots:
         QCOMPARE(model.rowCount(), 0);
 
         DisassemblyOutput disassemblyOutput =
-            DisassemblyOutput::disassemble(QStringLiteral("objdump"), QStringLiteral("x86_64"), {}, {}, symbol);
+            DisassemblyOutput::disassemble(QStringLiteral("objdump"), QStringLiteral("x86_64"), {}, {}, {}, {}, symbol);
         model.setDisassembly(disassemblyOutput, results);
         QCOMPARE(model.columnCount(), DisassemblyModel::COLUMN_COUNT + results.selfCosts.numTypes());
         QCOMPARE(model.rowCount(), disassemblyOutput.disassemblyLines.size());
@@ -392,7 +392,7 @@ private slots:
         QCOMPARE(model.rowCount(), 0);
 
         DisassemblyOutput disassemblyOutput =
-            DisassemblyOutput::disassemble(QStringLiteral("objdump"), QStringLiteral("x86_64"), {}, {}, symbol);
+            DisassemblyOutput::disassemble(QStringLiteral("objdump"), QStringLiteral("x86_64"), {}, {}, {}, {}, symbol);
         model.setDisassembly(disassemblyOutput, results);
 
         // no source file name
@@ -436,7 +436,7 @@ private slots:
         QCOMPARE(model.rowCount(), 0);
 
         auto disassemblyOutput =
-            DisassemblyOutput::disassemble(QStringLiteral("objdump"), QStringLiteral("x86_64"), {}, {}, symbol);
+            DisassemblyOutput::disassemble(QStringLiteral("objdump"), QStringLiteral("x86_64"), {}, {}, {}, {}, symbol);
         QVERIFY(disassemblyOutput.errorMessage.isEmpty());
         model.setDisassembly(disassemblyOutput, {});
 


### PR DESCRIPTION
this patch add allows the user to add a custom source path which will
overwrite the source path provided in the binary
this makes the disassembler, ... work if the source code directory was
moved after creating the binary

closes: #418 