### PR TITLE
Disassembler inlining

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ remove_definitions(-DQT_NO_SIGNALS_SLOTS_KEYWORDS)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_subdirectory(models)
+add_subdirectory(disassembler)
 
 ecm_install_icons(
     ICONS
@@ -89,10 +90,7 @@ if(QCustomPlot_FOUND)
     set(HOTSPOT_SRCS ${HOTSPOT_SRCS} frequencypage.cpp)
 endif()
 
-add_executable(
-    hotspot
-    ${HOTSPOT_SRCS}
-)
+add_executable(hotspot ${HOTSPOT_SRCS})
 
 target_link_libraries(
     hotspot
@@ -113,6 +111,7 @@ target_link_libraries(
     KF5::IconThemes
     KF5::Parts
     models
+    disassembler
     PrefixTickLabels
     KDAB::kddockwidgets
 )
@@ -125,13 +124,11 @@ if(QCustomPlot_FOUND)
     target_link_libraries(hotspot QCustomPlot::QCustomPlot)
 endif()
 
-set_target_properties(hotspot PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${KDE_INSTALL_BINDIR}")
+set_target_properties(
+    hotspot
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${KDE_INSTALL_BINDIR}"
+)
 
-install(
-    TARGETS hotspot
-    RUNTIME DESTINATION ${KDE_INSTALL_BINDIR}
-)
-install(
-    FILES hotspot.notifyrc
-    DESTINATION ${KDE_INSTALL_KNOTIFY5RCDIR}
-)
+install(TARGETS hotspot RUNTIME DESTINATION ${KDE_INSTALL_BINDIR})
+install(FILES hotspot.notifyrc DESTINATION ${KDE_INSTALL_KNOTIFY5RCDIR})

--- a/src/disassembler/CMakeLists.txt
+++ b/src/disassembler/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(
+    disassembler STATIC
+    disassemble.cpp dwarfdump.cpp
+)
+
+target_link_libraries(
+    disassembler
+    PUBLIC ${LIBDW_LIBRARIES} Qt::Core models
+)
+target_include_directories(
+    disassembler
+    PUBLIC ${LIBDWARF_INCLUDE_DIRS}
+)

--- a/src/disassembler/disassemble.cpp
+++ b/src/disassembler/disassemble.cpp
@@ -1,0 +1,19 @@
+/*
+    SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
+    SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#include "disassemble.h"
+#include "dwarfdump.h"
+
+Disassembly disassemble(const Data::Symbol& symbol)
+{
+    // TODO: find debug info
+    auto dwarfInfo = createSourceCodeFromDwarf(symbol);
+
+    return {dwarfInfo.mapping, dwarfInfo.inlinedFunctions, dwarfInfo.sourceCode,
+            DisassemblyOutput::disassemble(QStringLiteral("objdump"), {}, {}, {}, {}, {}, symbol),
+            dwarfInfo.declarationLine};
+}

--- a/src/disassembler/disassemble.h
+++ b/src/disassembler/disassemble.h
@@ -1,0 +1,38 @@
+/*
+    SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
+    SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#pragma once
+
+#include "../models/data.h"
+#include "../models/disassemblyoutput.h"
+
+// map pc to line number
+struct AddressLineMapping
+{
+    quint64 addr;
+    int linenumber;
+};
+Q_DECLARE_TYPEINFO(AddressLineMapping, Q_MOVABLE_TYPE);
+
+struct InlinedFunction
+{
+    quint64 lowpc;
+    quint64 highpc;
+    QString name;
+};
+Q_DECLARE_TYPEINFO(InlinedFunction, Q_MOVABLE_TYPE);
+
+struct Disassembly
+{
+    QVector<AddressLineMapping> lineMapping;
+    QVector<InlinedFunction> inlinedFunctions;
+    QVector<QString> sourceCode;
+    DisassemblyOutput disassembly;
+    int startLineNumber = 0;
+};
+
+Disassembly disassemble(const Data::Symbol& symbol);

--- a/src/disassembler/dwarfdump.cpp
+++ b/src/disassembler/dwarfdump.cpp
@@ -1,0 +1,255 @@
+/*
+    SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
+    SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#include "dwarfdump.h"
+
+#include "disassemble.h"
+#include <cstddef>
+#include <cstring>
+#include <dwarf.h>
+#include <elfutils/libdw.h>
+#include <fcntl.h>
+
+#include <QFile>
+#include <QLoggingCategory>
+#include <QScopeGuard>
+#include <QVector>
+
+#include "../models/data.h"
+
+namespace {
+Q_LOGGING_CATEGORY(disassembler, "hotspot.disassembler")
+
+template<typename Func>
+void inspect(Dwarf_Die* die, Func func)
+{
+    if (dwarf_haschildren(die)) {
+        Dwarf_Die child_die;
+        if (dwarf_child(die, &child_die) == 0) {
+            if (func(&child_die))
+                return;
+            inspect(&child_die, func);
+        }
+    }
+
+    Dwarf_Die sibling;
+    if (dwarf_siblingof(die, &sibling) == 0) {
+        if (func(&sibling))
+            return;
+        inspect(&sibling, func);
+    }
+}
+
+quint64 lowpc(Dwarf_Die* die)
+{
+    Dwarf_Addr addr = 0;
+    if (dwarf_lowpc(die, &addr) != 0) {
+        qCWarning(disassembler) << "Failed to fetch lowpc" << dwarf_errmsg(dwarf_errno());
+    }
+    return addr;
+}
+
+quint64 highpc(Dwarf_Die* die)
+{
+    Dwarf_Addr addr = 0;
+    if (dwarf_highpc(die, &addr) != 0) {
+        qCWarning(disassembler) << "Failed to fetch lowpc" << dwarf_errmsg(dwarf_errno());
+    }
+    return addr;
+}
+
+Dwarf_Die* findDieForSymbolName(quint64 lowpc, Dwarf_Die* die)
+{
+    if (dwarf_tag(die) == DW_TAG_subprogram) {
+        Dwarf_Addr curLowpc = -1;
+        dwarf_lowpc(die, &curLowpc);
+        if (lowpc == curLowpc) {
+            return die;
+        }
+    }
+
+    if (dwarf_haschildren(die)) {
+        Dwarf_Die child_die;
+        if (dwarf_child(die, &child_die) == 0) {
+            auto result = findDieForSymbolName(lowpc, &child_die);
+            if (result != nullptr) {
+                return result;
+            }
+        }
+    }
+
+    Dwarf_Die sibling;
+    if (dwarf_siblingof(die, &sibling) == 0) {
+        auto result = findDieForSymbolName(lowpc, &sibling);
+        if (result != nullptr) {
+            return result;
+        }
+    }
+
+    return nullptr;
+}
+
+QVector<InlinedFunction> findInlinedFunctionsForDie(Dwarf_Die* die)
+{
+    if (!dwarf_haschildren(die)) {
+        return {};
+    }
+
+    qDebug() << __FUNCTION__ << dwarf_diename(die);
+    Dwarf_Die child;
+
+    if (dwarf_child(die, &child) != 0) {
+        // that should not happend
+        qDebug() << "err";
+    }
+    qDebug() << dwarf_diename(&child);
+    qDebug() << (void*)&child;
+
+    QVector<InlinedFunction> inlinedFunctions;
+
+    auto findInlined = [&inlinedFunctions](Dwarf_Die* die) mutable {
+        if (dwarf_tag(die) == DW_TAG_inlined_subroutine) {
+            InlinedFunction function;
+            function.lowpc = lowpc(die);
+            function.highpc = highpc(die);
+            function.name = QString::fromUtf8(dwarf_diename(die));
+            inlinedFunctions.push_back(function);
+        }
+        return false;
+    };
+
+    findInlined(die);
+    inspect(die, findInlined);
+
+    return inlinedFunctions;
+}
+}
+
+DwarfInfo createSourceCodeFromDwarf(const Data::Symbol& symbol)
+{
+    QFile binary(symbol.actualPath);
+    binary.open(QIODevice::ReadOnly);
+
+    if (!binary.isOpen()) {
+        qCWarning(disassembler) << "Failed to open: " << symbol.binary;
+        return {};
+    }
+
+    auto dwarf_handle = dwarf_begin(binary.handle(), DWARF_C_READ);
+
+    auto cleanup = qScopeGuard([dwarf_handle] { dwarf_end(dwarf_handle); });
+
+    Dwarf_Die cudieMemory;
+
+    auto cudie = dwarf_addrdie(dwarf_handle, symbol.relAddr, &cudieMemory);
+
+    if (cudie == nullptr) {
+        qCWarning(disassembler) << "Failed to find cudie for symbol" << symbol.prettySymbol;
+        return {};
+    }
+
+    Dwarf_Files* sourceFiles = nullptr;
+    size_t sourceFilesCount = -1;
+    if (dwarf_getsrcfiles(cudie, &sourceFiles, &sourceFilesCount) == -1) {
+        qCWarning(disassembler) << "Failed to get source files for symbol" << symbol.prettySymbol;
+        return {};
+    }
+
+    Dwarf_Lines* sourceLines = nullptr;
+    size_t sourceLineCount = -1;
+    if (dwarf_getsrclines(cudie, &sourceLines, &sourceLineCount) != 0) {
+        qCWarning(disassembler) << "Failed to get source lines for symbol" << symbol.prettySymbol;
+        return {};
+    }
+
+    auto die = findDieForSymbolName(symbol.relAddr, cudie);
+    qDebug() << dwarf_diename(die);
+    if (die == nullptr) {
+        qCWarning(disassembler) << "Failed to find die for symbol" << symbol.prettySymbol;
+        return {};
+    }
+
+    int declLine = -1;
+    if (dwarf_decl_line(die, &declLine) != 0) {
+        qCWarning(disassembler) << "Failed to get line declaration of symbol" << symbol.prettySymbol;
+        return {};
+    }
+
+    Dwarf_Word fileIndex = -1;
+    Dwarf_Attribute attributeMemory;
+    auto attribute = dwarf_attr(die, DW_AT_decl_file, &attributeMemory);
+
+    if (attribute == nullptr) {
+        qCWarning(disassembler) << "Failed to get declaration file index for symbol" << symbol.prettySymbol;
+        return {};
+    }
+
+    if (dwarf_formudata(attribute, &fileIndex) != 0) {
+        qCWarning(disassembler) << "Failed to get declaration file index for symbol" << symbol.prettySymbol;
+        return {};
+    }
+
+    auto sourceFileName = dwarf_filesrc(sourceFiles, fileIndex, nullptr, nullptr);
+
+    // create a mapping of address -> linenumber
+    QVector<AddressLineMapping> mapping;
+    mapping.resize(static_cast<int>(sourceLineCount));
+
+    for (size_t i = 0; i < sourceLineCount; i++) {
+        auto line = dwarf_onesrcline(sourceLines, i);
+        Dwarf_Addr addr = -1;
+        // TODO: error checking
+        dwarf_lineaddr(line, &addr);
+        int lineNumber = -1;
+        dwarf_lineno(line, &lineNumber);
+        mapping.push_back({addr, lineNumber});
+    }
+
+    Dwarf_Addr highpc = -1;
+    if (dwarf_highpc(die, &highpc) != 0) {
+        qCWarning(disassembler) << "Failed to get highpc of symbol" << symbol.prettySymbol;
+        return {};
+    }
+
+    // Highpc points to the first instruction after the function. To get the last line of the function we need to
+    // use mapping[highpc_entry -1].lineno
+
+    auto it = std::find_if(mapping.cbegin(), mapping.cend(),
+                           [highpc](AddressLineMapping mapping) { return highpc == mapping.addr; });
+    if (it == mapping.cend()) {
+        qCWarning(disassembler) << "Failed to find last line of symbol" << symbol.prettySymbol;
+        return {};
+    }
+
+    int lastLine = std::prev(it)->linenumber;
+
+    QVector<QString> sourceCode;
+    sourceCode.reserve(lastLine - declLine);
+
+    QFile sourceFile(QString::fromLocal8Bit(sourceFileName));
+    sourceFile.open(QIODevice::ReadOnly);
+
+    if (!sourceFile.isOpen()) {
+        qCWarning(disassembler) << "Failed to open source file" << sourceFileName;
+        return {};
+    }
+
+    // linenumber -> starts at 1 and not at 0
+    for (int i = 1; i < declLine; i++) {
+        sourceFile.readLine();
+    }
+
+    for (int i = declLine; i <= lastLine; i++) {
+        auto line = QString::fromUtf8(sourceFile.readLine());
+        if (line.endsWith(QLatin1Char('\n'))) {
+            line.chop(1);
+        }
+        sourceCode.push_back(line);
+    }
+
+    return {mapping, sourceCode, findInlinedFunctionsForDie(die), declLine};
+}

--- a/src/disassembler/dwarfdump.h
+++ b/src/disassembler/dwarfdump.h
@@ -1,0 +1,29 @@
+/*
+    SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
+    SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#pragma once
+
+#include <QString>
+#include <QVector>
+#include <QtGlobal>
+#include <qvector.h>
+
+#include "disassemble.h"
+
+namespace Data {
+struct Symbol;
+}
+
+struct DwarfInfo
+{
+    QVector<AddressLineMapping> mapping;
+    QVector<QString> sourceCode;
+    QVector<InlinedFunction> inlinedFunctions;
+    int declarationLine = 0;
+};
+
+DwarfInfo createSourceCodeFromDwarf(const Data::Symbol& symbol);

--- a/src/models/CMakeLists.txt
+++ b/src/models/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(
     codedelegate.cpp
     costdelegate.cpp
     data.cpp
+    disassemblyentry.cpp
     disassemblymodel.cpp
     disassemblyoutput.cpp
     eventmodel.cpp

--- a/src/models/disassemblyentry.cpp
+++ b/src/models/disassemblyentry.cpp
@@ -1,0 +1,112 @@
+/*
+    SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
+    SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#include "disassemblyentry.h"
+
+DisassemblyEntry::DisassemblyEntry(DisassemblyEntry* parent, const DisassemblyOutput::DisassemblyLine& disassemblyLine,
+                                   QTextLine textLine)
+    : m_parent(parent)
+    , m_disassemblyLine(disassemblyLine)
+    , m_textLine(textLine)
+{
+    if (parent) {
+        m_row = m_parent->childCount();
+    } else {
+        m_row = 0;
+    }
+}
+
+DisassemblyEntry* DisassemblyEntry::lastChild()
+{
+    if (m_lines.isEmpty()) {
+        return nullptr;
+    }
+
+    return &m_lines[m_lines.size() - 1];
+}
+
+void DisassemblyEntry::addChild(const DisassemblyEntry& line)
+{
+    m_lines.push_back(line);
+}
+
+void DisassemblyEntry::clear()
+{
+    m_lines.clear();
+}
+
+bool DisassemblyEntry::operator==(const DisassemblyEntry& other) const
+{
+    return std::tie(m_parent, m_lines, m_disassemblyLine, m_row)
+        == std::tie(other.m_parent, other.m_lines, other.m_disassemblyLine, other.m_row);
+}
+
+int DisassemblyEntry::findOffsetOf(const DisassemblyEntry* entry) const
+{
+    auto found = std::find_if(m_lines.begin(), m_lines.end(),
+                              [needle = entry](const DisassemblyEntry& entry) { return needle == &entry; });
+
+    if (found != m_lines.end()) {
+        return std::distance(m_lines.begin(), found);
+    }
+
+    return -1;
+}
+
+DisassemblyEntry::TreeIterator::TreeIterator(const DisassemblyEntry* entry, int child)
+    : m_entry(const_cast<DisassemblyEntry*>(entry))
+    , m_child(child)
+{
+}
+
+DisassemblyEntry& DisassemblyEntry::TreeIterator::operator*() const
+{
+    if (m_entry->childCount() == 0) {
+        return *m_entry;
+    }
+    return *m_entry->child(m_child);
+}
+
+DisassemblyEntry* DisassemblyEntry::TreeIterator::operator->() const
+{
+    if (m_entry->childCount() == 0) {
+        return m_entry;
+    }
+    return m_entry->child(m_child);
+}
+
+DisassemblyEntry::TreeIterator& DisassemblyEntry::TreeIterator::operator++()
+{
+    if (m_entry->childCount() == 0) {
+        m_entry++;
+        return *this;
+    }
+
+    m_child++;
+
+    if (m_child >= m_entry->childCount()) {
+        m_entry++;
+        m_child = 0;
+    }
+
+    return *this;
+}
+
+bool DisassemblyEntry::TreeIterator::operator==(const DisassemblyEntry::TreeIterator other) const
+{
+    return this->m_entry == other.m_entry && this->m_child == other.m_child;
+}
+
+DisassemblyEntry::TreeIterator DisassemblyEntry::tree_begin() const
+{
+    return TreeIterator(&m_lines[0], 0);
+}
+
+DisassemblyEntry::TreeIterator DisassemblyEntry::tree_end() const
+{
+    return TreeIterator(m_lines.end(), 0);
+}

--- a/src/models/disassemblyentry.h
+++ b/src/models/disassemblyentry.h
@@ -1,0 +1,103 @@
+/*
+    SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
+    SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#pragma once
+
+#include "disassemblyoutput.h"
+#include <iterator>
+#include <QTextLine>
+#include <QVector>
+
+class DisassemblyEntry
+{
+public:
+    DisassemblyEntry(DisassemblyEntry* parent, const DisassemblyOutput::DisassemblyLine& disassemblyLine = {},
+                     QTextLine textLine = {});
+
+    ~DisassemblyEntry() = default;
+
+    DisassemblyEntry* parent() const
+    {
+        return m_parent;
+    }
+
+    int row() const
+    {
+        return m_row;
+    }
+
+    DisassemblyEntry* child(int row)
+    {
+        return &m_lines[row];
+    }
+
+    DisassemblyEntry* child(int row) const
+    {
+        return const_cast<DisassemblyEntry*>(&m_lines[row]);
+    }
+
+    DisassemblyEntry* lastChild();
+
+    DisassemblyOutput::DisassemblyLine disassemblyLine() const
+    {
+        return m_disassemblyLine;
+    }
+
+    QTextLine textLine() const
+    {
+        return m_textLine;
+    }
+
+    int childCount() const
+    {
+        return m_lines.size();
+    }
+
+    void clear();
+    void addChild(const DisassemblyEntry& line);
+
+    bool operator==(const DisassemblyEntry& other) const;
+
+    int findOffsetOf(const DisassemblyEntry* entry) const;
+
+    // an iterator that will iterate over all children and grandchildren
+    class TreeIterator : public std::iterator<std::forward_iterator_tag, DisassemblyEntry>
+    {
+    public:
+        TreeIterator(const DisassemblyEntry* entry, int child);
+        DisassemblyEntry& operator*() const;
+        DisassemblyEntry* operator->() const;
+
+        TreeIterator& operator++();
+        TreeIterator operator++(int)
+        {
+            TreeIterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        bool operator==(const TreeIterator other) const;
+        bool operator!=(const TreeIterator other) const
+        {
+            return !(*this == other);
+        }
+
+    private:
+        DisassemblyEntry* m_entry = nullptr;
+        int m_child = -1;
+    };
+
+    TreeIterator tree_begin() const;
+    TreeIterator tree_end() const;
+
+private:
+    DisassemblyEntry* m_parent;
+    QVector<DisassemblyEntry> m_lines;
+    DisassemblyOutput::DisassemblyLine m_disassemblyLine;
+    QTextLine m_textLine;
+    int m_row;
+};

--- a/src/models/disassemblymodel.cpp
+++ b/src/models/disassemblymodel.cpp
@@ -18,9 +18,10 @@
 #include "sourcecodemodel.h"
 
 DisassemblyModel::DisassemblyModel(KSyntaxHighlighting::Repository* repository, QObject* parent)
-    : QAbstractTableModel(parent)
+    : QAbstractItemModel(parent)
     , m_document(new QTextDocument(this))
     , m_highlighter(new Highlighter(m_document, repository, this))
+    , m_disassemblyLines(nullptr)
 {
     m_document->setUndoRedoEnabled(false);
 }
@@ -39,13 +40,56 @@ QModelIndex DisassemblyModel::findIndexWithOffset(int offset)
     quint64 address = m_data.disassemblyLines[0].addr + offset;
 
     const auto& found =
-        std::find_if(m_data.disassemblyLines.begin(), m_data.disassemblyLines.end(),
-                     [address](const DisassemblyOutput::DisassemblyLine& line) { return line.addr == address; });
+        std::find_if(m_disassemblyLines.tree_begin(), m_disassemblyLines.tree_end(),
+                     [address](const DisassemblyEntry& entry) { return entry.disassemblyLine().addr == address; });
 
-    if (found != m_data.disassemblyLines.end()) {
-        return createIndex(std::distance(m_data.disassemblyLines.begin(), found), DisassemblyColumn);
+    if (found != m_disassemblyLines.tree_end()) {
+        return indexFromEntry(&(*found));
     }
+
     return {};
+}
+
+QModelIndex DisassemblyModel::parent(const QModelIndex& index) const
+{
+    if (!index.isValid()) {
+        return QModelIndex();
+    }
+
+    DisassemblyEntry* line = static_cast<DisassemblyEntry*>(index.internalPointer());
+
+    if (line == nullptr) {
+        return QModelIndex();
+    }
+
+    auto parentItem = line->parent();
+
+    if (parentItem == &m_disassemblyLines) {
+        return QModelIndex();
+    }
+
+    return createIndex(parentItem->row(), 0, parentItem);
+}
+
+QModelIndex DisassemblyModel::index(int row, int column, const QModelIndex& parent) const
+{
+    if (!hasIndex(row, column, parent)) {
+        return QModelIndex();
+    }
+
+    DisassemblyEntry* parentItem;
+
+    if (!parent.isValid()) {
+        parentItem = const_cast<DisassemblyEntry*>(&m_disassemblyLines);
+    } else {
+        parentItem = static_cast<DisassemblyEntry*>(parent.internalPointer());
+    }
+
+    if (row < parentItem->childCount()) {
+        return createIndex(row, column, parentItem->child(row));
+    } else {
+        return QModelIndex();
+    }
 }
 
 void DisassemblyModel::setDisassembly(const DisassemblyOutput& disassemblyOutput,
@@ -58,9 +102,11 @@ void DisassemblyModel::setDisassembly(const DisassemblyOutput& disassemblyOutput
     m_numTypes = results.selfCosts.numTypes();
 
     m_document->clear();
+    m_disassemblyLines.clear();
 
     QTextCursor cursor(m_document);
     cursor.beginEditBlock();
+    DisassemblyEntry* lastChild = nullptr;
     for (const auto& it : disassemblyOutput.disassemblyLines) {
         cursor.insertText(it.disassembly);
         cursor.insertBlock();
@@ -68,6 +114,30 @@ void DisassemblyModel::setDisassembly(const DisassemblyOutput& disassemblyOutput
     cursor.endEditBlock();
 
     m_document->setTextWidth(m_document->idealWidth());
+
+    int linecounter = 0;
+    QString function;
+    for (const auto& it : disassemblyOutput.disassemblyLines) {
+        auto textLine = m_document->findBlockByLineNumber(linecounter++).layout()->lineAt(0);
+
+        // if symbol in not empty -> inlined function detected
+        if (!it.symbol.isEmpty()) {
+            // only collapse the same function
+            if (lastChild && function == it.symbol) {
+                lastChild->addChild({lastChild, it, textLine});
+            } else {
+                m_disassemblyLines.addChild(
+                    {&m_disassemblyLines, {0, QLatin1String("%1 [inlined]").arg(it.symbol), {}, {}, {}}});
+                lastChild = m_disassemblyLines.lastChild();
+                Q_ASSERT(lastChild);
+                lastChild->addChild({lastChild, it, textLine});
+                function = it.symbol;
+            }
+        } else {
+            lastChild = nullptr;
+            m_disassemblyLines.addChild({&m_disassemblyLines, it, textLine});
+        }
+    }
 
     endResetModel();
 }
@@ -108,29 +178,30 @@ QVariant DisassemblyModel::data(const QModelIndex& index, int role) const
         return static_cast<int>(Qt::AlignLeft | Qt::AlignVCenter);
     }
 
-    const auto& data = m_data.disassemblyLines.at(index.row());
+    DisassemblyEntry* entry = static_cast<DisassemblyEntry*>(index.internalPointer());
+    Q_ASSERT(entry);
+    auto line = entry->disassemblyLine();
 
     if (role == Qt::DisplayRole || role == CostRole || role == TotalCostRole || role == SyntaxHighlightRole
         || role == Qt::ToolTipRole) {
         if (role != Qt::ToolTipRole) {
             if (index.column() == AddrColumn) {
-                if (!data.addr)
+                if (!line.addr)
                     return {};
-                return QString::number(data.addr, 16);
+                return QString::number(line.addr, 16);
             } else if (index.column() == DisassemblyColumn) {
-                const auto block = m_document->findBlockByLineNumber(index.row());
                 if (role == SyntaxHighlightRole)
-                    return QVariant::fromValue(block.layout()->lineAt(0));
-                return block.text();
+                    return QVariant::fromValue(entry->textLine());
+                return line.disassembly;
             }
         }
 
-        if (data.addr == 0) {
+        if (line.addr == 0) {
             return {};
         }
 
         const auto entry = m_results.entries.value(m_data.symbol);
-        auto it = entry.offsetMap.find(data.addr);
+        auto it = entry.offsetMap.find(line.addr);
         if (it != entry.offsetMap.end()) {
             int event = index.column() - COLUMN_COUNT;
 
@@ -144,7 +215,7 @@ QVariant DisassemblyModel::data(const QModelIndex& index, int role) const
                 return totalCost;
             } else if (role == Qt::ToolTipRole) {
                 auto tooltip = tr("addr: <tt>%1</tt><br/>assembly: <tt>%2</tt><br/>disassembly: <tt>%3</tt>")
-                                   .arg(QString::number(data.addr, 16), data.disassembly);
+                                   .arg(QString::number(line.addr, 16), line.disassembly);
                 return Util::formatTooltip(tooltip, locationCost, m_results.selfCosts);
             }
 
@@ -154,18 +225,23 @@ QVariant DisassemblyModel::data(const QModelIndex& index, int role) const
         } else {
             if (role == Qt::ToolTipRole)
                 return tr("<qt><tt>%1</tt><hr/>No samples at this location.</qt>")
-                    .arg(data.disassembly.toHtmlEscaped());
+                    .arg(line.disassembly.toHtmlEscaped());
             else
                 return QString();
         }
     } else if (role == DisassemblyModel::HighlightRole) {
-        return data.fileLine.line == m_highlightLine;
+        return line.fileLine.line == m_highlightLine;
     } else if (role == LinkedFunctionNameRole) {
-        return data.linkedFunction.name;
+        return line.linkedFunction.name;
     } else if (role == LinkedFunctionOffsetRole) {
-        return data.linkedFunction.offset;
-    } else if (role == RainbowLineNumberRole && data.addr) {
-        return data.fileLine.line;
+        return line.linkedFunction.offset;
+    } else if (role == RainbowLineNumberRole && line.addr) {
+        // don't color inlined stuff because that is confusing
+        // TODO find better solution like coloring in the color of the calling line
+        if (line.symbol.isEmpty()) {
+            return line.fileLine.line;
+        }
+        return -1;
     }
 
     return {};
@@ -173,12 +249,19 @@ QVariant DisassemblyModel::data(const QModelIndex& index, int role) const
 
 int DisassemblyModel::columnCount(const QModelIndex& parent) const
 {
-    return parent.isValid() ? 0 : COLUMN_COUNT + m_numTypes;
+    Q_UNUSED(parent);
+    return COLUMN_COUNT + m_numTypes;
 }
 
 int DisassemblyModel::rowCount(const QModelIndex& parent) const
 {
-    return parent.isValid() ? 0 : m_data.disassemblyLines.count();
+    if (parent.column() > 0)
+        return 0;
+    if (parent.isValid()) {
+        auto item = static_cast<DisassemblyEntry*>(parent.internalPointer());
+        return item->childCount();
+    }
+    return m_disassemblyLines.childCount();
 }
 
 void DisassemblyModel::updateHighlighting(int line)
@@ -189,39 +272,50 @@ void DisassemblyModel::updateHighlighting(int line)
 
 Data::FileLine DisassemblyModel::fileLineForIndex(const QModelIndex& index) const
 {
-    return m_data.disassemblyLines[index.row()].fileLine;
+    auto entry = reinterpret_cast<DisassemblyEntry*>(index.internalPointer());
+    return entry->disassemblyLine().fileLine;
 }
 
 QModelIndex DisassemblyModel::indexForFileLine(const Data::FileLine& fileLine) const
 {
-    int i = -1;
-    int bestMatch = -1;
+    DisassemblyEntry* bestMatch = nullptr;
     qint64 bestCost = 0;
     const auto entry = m_results.entries.value(m_data.symbol);
-    for (const auto& line : m_data.disassemblyLines) {
-        ++i;
-        if (line.fileLine != fileLine) {
+
+    for (auto line = m_disassemblyLines.tree_begin(); line != m_disassemblyLines.tree_end(); line++) {
+        if (line->disassemblyLine().fileLine != fileLine) {
             continue;
         }
 
-        if (bestMatch == -1) {
-            bestMatch = i;
+        if (!bestMatch) {
+            bestMatch = &(*line);
         }
 
-        auto it = entry.offsetMap.find(line.addr);
+        auto it = entry.offsetMap.find(line->disassemblyLine().addr);
         if (it != entry.offsetMap.end()) {
             const auto& locationCost = it.value();
 
             if (!bestCost || bestCost < locationCost.selfCost[0]) {
-                bestMatch = i;
+                bestMatch = &(*line);
                 bestCost = locationCost.selfCost[0];
             }
         }
     }
 
-    if (bestMatch == -1)
+    if (!bestMatch)
         return {};
-    return index(bestMatch, 0);
+
+    return indexFromEntry(bestMatch);
+}
+
+QModelIndex DisassemblyModel::indexFromEntry(DisassemblyEntry* entry) const
+{
+    Q_ASSERT(entry);
+
+    int index = entry->parent()->findOffsetOf(entry);
+    Q_ASSERT(index >= 0);
+
+    return createIndex(index, 0, entry);
 }
 
 void DisassemblyModel::find(const QString& search, Direction direction, int offset)

--- a/src/models/disassemblymodel.h
+++ b/src/models/disassemblymodel.h
@@ -12,6 +12,7 @@
 #include <QAbstractItemModel>
 #include <QTextLine>
 
+#include "../disassembler/disassemble.h"
 #include "data.h"
 #include "disassemblyentry.h"
 #include "disassemblyoutput.h"
@@ -33,7 +34,7 @@ public:
     explicit DisassemblyModel(KSyntaxHighlighting::Repository* repository, QObject* parent = nullptr);
     ~DisassemblyModel();
 
-    void setDisassembly(const DisassemblyOutput& disassemblyOutput, const Data::CallerCalleeResults& results);
+    void setDisassembly(const Disassembly& disassembly, const Data::CallerCalleeResults& results);
 
     void clear();
     QModelIndex findIndexWithOffset(int offset);

--- a/src/models/disassemblymodel.h
+++ b/src/models/disassemblymodel.h
@@ -9,10 +9,11 @@
 #pragma once
 
 #include <memory>
-#include <QAbstractTableModel>
+#include <QAbstractItemModel>
 #include <QTextLine>
 
 #include "data.h"
+#include "disassemblyentry.h"
 #include "disassemblyoutput.h"
 
 class QTextDocument;
@@ -25,7 +26,7 @@ class Repository;
 
 enum class Direction;
 
-class DisassemblyModel : public QAbstractTableModel
+class DisassemblyModel : public QAbstractItemModel
 {
     Q_OBJECT
 public:
@@ -36,6 +37,9 @@ public:
 
     void clear();
     QModelIndex findIndexWithOffset(int offset);
+
+    QModelIndex parent(const QModelIndex& index) const override;
+    QModelIndex index(int row, int column, const QModelIndex& parent) const override;
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
@@ -78,8 +82,11 @@ public slots:
     void find(const QString& search, Direction direction, int offset);
 
 private:
+    QModelIndex indexFromEntry(DisassemblyEntry* entry) const;
+
     QTextDocument* m_document;
     Highlighter* m_highlighter;
+    DisassemblyEntry m_disassemblyLines;
     DisassemblyOutput m_data;
     Data::CallerCalleeResults m_results;
     int m_numTypes = 0;

--- a/src/models/disassemblyoutput.cpp
+++ b/src/models/disassemblyoutput.cpp
@@ -193,6 +193,7 @@ static ObjectdumpOutput objdumpParse(const QByteArray& output)
         if (asmLine.startsWith(QLatin1Char('/')) && asmLine.contains(QStringLiteral("file format"))) {
             continue;
         } else if (asmLine.startsWith(QLatin1Char('/')) || asmLine.startsWith(QLatin1Char('.'))) {
+            // TODO: Remove
             // extract source code line info
             // these look like this:
             // - /usr/include/c++/11.2.0/bits/stl_tree.h:2083 (discriminator 1)
@@ -275,7 +276,6 @@ DisassemblyOutput DisassemblyOutput::disassemble(const QString& objdump, const Q
     // Call objdump with arguments: addresses range and binary file
     auto toHex = [](quint64 addr) -> QString { return QLatin1String("0x") + QString::number(addr, 16); };
     auto arguments = QStringList {QStringLiteral("-d"), // disassemble
-                                  QStringLiteral("-l"), // include source code lines
                                   QStringLiteral("-C"), // demangle names
                                   QStringLiteral("--start-address"),
                                   toHex(symbol.relAddr),

--- a/src/models/disassemblyoutput.h
+++ b/src/models/disassemblyoutput.h
@@ -19,6 +19,10 @@ struct DisassemblyOutput
         QString name;
         int offset = 0; // offset from the entrypoint of the function
     };
+    friend bool operator==(const LinkedFunction& a, const LinkedFunction& b)
+    {
+        return a.name == b.name && a.offset == b.offset;
+    }
 
     struct DisassemblyLine
     {
@@ -26,7 +30,15 @@ struct DisassemblyOutput
         QString disassembly;
         LinkedFunction linkedFunction;
         Data::FileLine fileLine;
+        QString symbol; // used to show which function was inlined
     };
+
+    friend bool operator==(const DisassemblyLine& a, const DisassemblyLine& b)
+    {
+        return std::tie(a.addr, a.disassembly, a.linkedFunction, a.fileLine, a.symbol)
+            == std::tie(b.addr, b.disassembly, b.linkedFunction, b.fileLine, b.symbol);
+    }
+
     QVector<DisassemblyLine> disassemblyLines;
 
     quint64 baseAddress = 0;

--- a/src/models/sourcecodemodel.cpp
+++ b/src/models/sourcecodemodel.cpp
@@ -79,15 +79,21 @@ void SourceCodeModel::setDisassembly(const DisassemblyOutput& disassemblyOutput,
     const auto entry = results.entries.find(disassemblyOutput.symbol);
 
     for (const auto& line : disassemblyOutput.disassemblyLines) {
-        if (line.fileLine.line == 0 || line.fileLine.file != disassemblyOutput.mainSourceFileName) {
+        // symbol not empty -> inlined function
+        // skip all lines that are not part of the function (happens due to inlining)
+        if (line.fileLine.line == 0 || !line.symbol.isEmpty()) {
             continue;
         }
 
-        if (line.fileLine.line > maxLineNumber) {
-            maxLineNumber = line.fileLine.line;
-        }
-        if (line.fileLine.line < minLineNumber) {
-            minLineNumber = line.fileLine.line;
+        // maxLineNumber and minLineNumber are used to show the source code so we only update them when we are in the
+        // current file
+        if (line.fileLine.file == disassemblyOutput.mainSourceFileName) {
+            if (line.fileLine.line > maxLineNumber) {
+                maxLineNumber = line.fileLine.line;
+            }
+            if (line.fileLine.line < minLineNumber) {
+                minLineNumber = line.fileLine.line;
+            }
         }
 
         if (m_validLineNumbers.contains(line.fileLine.line))

--- a/src/models/sourcecodemodel.cpp
+++ b/src/models/sourcecodemodel.cpp
@@ -85,6 +85,8 @@ void SourceCodeModel::setDisassembly(const DisassemblyOutput& disassemblyOutput,
             continue;
         }
 
+        qDebug() << line.fileLine;
+
         // maxLineNumber and minLineNumber are used to show the source code so we only update them when we are in the
         // current file
         if (line.fileLine.file == disassemblyOutput.mainSourceFileName) {

--- a/src/models/sourcecodemodel.h
+++ b/src/models/sourcecodemodel.h
@@ -8,27 +8,23 @@
 #pragma once
 
 #include "data.h"
-#include "disassemblyoutput.h"
 
 #include <memory>
 #include <QAbstractTableModel>
 #include <QTextLine>
 
+#include "../disassembler/disassemble.h"
+
 class QTextDocument;
 
 class Highlighter;
+
+struct Disassembly;
 
 namespace KSyntaxHighlighting {
 class Repository;
 class Definition;
 }
-
-struct SourceCodeLine
-{
-    QString text;
-    QTextLine line;
-};
-Q_DECLARE_TYPEINFO(SourceCodeLine, Q_MOVABLE_TYPE);
 
 enum class Direction;
 
@@ -42,7 +38,7 @@ public:
     ~SourceCodeModel();
 
     void clear();
-    void setDisassembly(const DisassemblyOutput& disassemblyOutput, const Data::CallerCalleeResults& results);
+    void setDisassembly(const Disassembly& disassembly, const Data::CallerCalleeResults& results);
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
@@ -89,7 +85,8 @@ private:
     QString m_sysroot;
     QSet<int> m_validLineNumbers;
     QTextDocument* m_document = nullptr;
-    QVector<SourceCodeLine> m_sourceCodeLines;
+    Disassembly m_disassembly;
+    QVector<QTextLine> m_highlightedLines;
     Highlighter* m_highlighter = nullptr;
     Data::Costs m_selfCosts;
     Data::Costs m_inclusiveCosts;

--- a/src/resultsdisassemblypage.cpp
+++ b/src/resultsdisassemblypage.cpp
@@ -126,7 +126,8 @@ ResultsDisassemblyPage::ResultsDisassemblyPage(CostContextMenu* costContextMenu,
         connect(sourceView, &QTreeView::clicked, sourceView, [=](const QModelIndex& index) {
             const auto fileLine = sourceModel->fileLineForIndex(index);
             if (fileLine.isValid()) {
-                destView->scrollTo(destModel->indexForFileLine(fileLine));
+                auto index = destModel->indexForFileLine(fileLine);
+                destView->scrollTo(index);
             }
         });
     };
@@ -142,8 +143,9 @@ ResultsDisassemblyPage::ResultsDisassemblyPage(CostContextMenu* costContextMenu,
         int functionOffset = index.data(DisassemblyModel::LinkedFunctionOffsetRole).toInt();
 
         if (m_symbolStack[m_stackIndex].symbol == functionName) {
-            ui->assemblyView->scrollTo(m_disassemblyModel->findIndexWithOffset(functionOffset),
-                                       QAbstractItemView::ScrollHint::PositionAtTop);
+            auto index = m_disassemblyModel->findIndexWithOffset(functionOffset);
+            ui->assemblyView->setExpanded(index, true);
+            ui->assemblyView->scrollTo(index, QAbstractItemView::ScrollHint::PositionAtTop);
         } else {
             const auto symbol =
                 std::find_if(m_callerCalleeResults.entries.keyBegin(), m_callerCalleeResults.entries.keyEnd(),

--- a/src/resultsdisassemblypage.cpp
+++ b/src/resultsdisassemblypage.cpp
@@ -327,7 +327,7 @@ void ResultsDisassemblyPage::setupAsmViewModel()
         ui->sourceCodeView->setItemDelegateForColumn(col, m_sourceCodeCostDelegate);
     }
 }
-
+#include "disassembler/disassemble.h"
 void ResultsDisassemblyPage::showDisassembly()
 {
     if (m_symbolStack.isEmpty())
@@ -392,8 +392,10 @@ void ResultsDisassemblyPage::showDisassembly(const DisassemblyOutput& disassembl
 
     ui->errorMessage->hide();
 
-    m_disassemblyModel->setDisassembly(disassemblyOutput, m_callerCalleeResults);
-    m_sourceCodeModel->setDisassembly(disassemblyOutput, m_callerCalleeResults);
+    auto disassembly = disassemble(disassemblyOutput.symbol);
+
+    m_disassemblyModel->setDisassembly(disassembly, m_callerCalleeResults);
+    m_sourceCodeModel->setDisassembly(disassembly, m_callerCalleeResults);
 
     ResultsUtil::hideEmptyColumns(m_callerCalleeResults.selfCosts, ui->assemblyView, DisassemblyModel::COLUMN_COUNT);
 

--- a/tests/modeltests/tst_models.cpp
+++ b/tests/modeltests/tst_models.cpp
@@ -429,6 +429,8 @@ private slots:
         const quint64 size = match.captured(2).toInt(&ok, 10);
         Q_ASSERT(ok);
 
+        qDebug() << output << address << size;
+
         Data::Symbol symbol = {QStringLiteral("main"), address, size, QStringLiteral("cpp-recursion"), {}, binary};
 
         SourceCodeModel model(nullptr);


### PR DESCRIPTION
this adds a simple detection for inlined code to elide it from the assembly view.

![grafik](https://github.com/KDAB/hotspot/assets/82457690/8296f3c1-fe39-4817-9529-78ead3d11dda)

I am not sure if this works correctly so it would be nice if someone has a minimal example to test this.
This currently brakes syntax highlighting and code navigation