### PR TITLE
add option to set custom source paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ Options:
                            libraries.
   --appPath <path>         Path to folder containing the application executable
                            and libraries.
+  --sourcePaths <paths>    Colon separated list of extra paths to the source
+                           code.
   --arch <path>            Architecture to use for unwinding.
   --exportTo <path>        Path to .perfparser output file to which the input
                            data should be exported. A single input file has to
@@ -325,6 +327,9 @@ which source code line.
 For easier navigation, you can simply click on a line and the other view will jump to it.
 You can follow function calls with a double click.
 In the sourcecode view you can press ctrl+f or press the search icon to open a search window.
+
+If you have the sources in different directory, you can use `--sourcePaths` or the settings to
+select tell the disassembler to search there for the source code.
 
 ## Known Issues
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,6 +137,12 @@ int main(int argc, char** argv)
         QStringLiteral("path"));
     parser.addOption(appPath);
 
+    QCommandLineOption sourcePath(
+        QStringLiteral("sourcePaths"),
+        QCoreApplication::translate("main", "Colon separated list of extra paths to the source code."),
+        QStringLiteral("paths"));
+    parser.addOption(sourcePath);
+
     QCommandLineOption arch(QStringLiteral("arch"),
                             QCoreApplication::translate("main", "Architecture to use for unwinding."),
                             QStringLiteral("path"));
@@ -176,6 +182,7 @@ int main(int argc, char** argv)
         applyArg(extraLibPaths, &Settings::setExtraLibPaths);
         applyArg(appPath, &Settings::setAppPath);
         applyArg(arch, &Settings::setArch);
+        applyArg(sourcePath, &Settings::setSourceCodePaths);
     };
 
     const auto settings = Settings::instance();

--- a/src/models/disassemblyoutput.cpp
+++ b/src/models/disassemblyoutput.cpp
@@ -303,7 +303,8 @@ DisassemblyOutput DisassemblyOutput::disassemble(const QString& objdump, const Q
 
     const auto objdumpOutput = objdumpParse(output);
     disassemblyOutput.disassemblyLines = objdumpOutput.disassemblyLines;
-    disassemblyOutput.mainSourceFileName =
+    disassemblyOutput.mainSourceFileName = objdumpOutput.mainSourceFileName;
+    disassemblyOutput.realSourceFileName =
         findSourceCodeFile(objdumpOutput.mainSourceFileName, sourceCodePaths, sysroot);
     return disassemblyOutput;
 }

--- a/src/models/disassemblyoutput.h
+++ b/src/models/disassemblyoutput.h
@@ -31,7 +31,10 @@ struct DisassemblyOutput
 
     quint64 baseAddress = 0;
     // due to inlining there can be multiple source files encountered in the disassembly lines above
+    // this is the file referenced in the debug infos
     QString mainSourceFileName;
+    // if the source file is moved this contains the path the the existing file
+    QString realSourceFileName;
 
     Data::Symbol symbol;
     QString errorMessage;

--- a/src/resultscallercalleepage.cpp
+++ b/src/resultscallercalleepage.cpp
@@ -283,8 +283,9 @@ void ResultsCallerCalleePage::openEditor(const Data::Symbol& symbol)
         const auto location = toSourceMapLocation(fileLine, symbol);
         if (location) {
             auto settings = Settings::instance();
+            const auto colon = QLatin1Char(':');
             auto remappedSourceFile =
-                findSourceCodeFile(location.path, settings->sourceCodePaths(), settings->sysroot());
+                findSourceCodeFile(location.path, settings->sourceCodePaths().split(colon), settings->sysroot());
             emit navigateToCode(remappedSourceFile, location.lineNumber, 0);
             return true;
         }

--- a/src/resultsdisassemblypage.cpp
+++ b/src/resultsdisassemblypage.cpp
@@ -102,6 +102,8 @@ ResultsDisassemblyPage::ResultsDisassemblyPage(CostContextMenu* costContextMenu,
         m_sourceCodeModel->updateHighlighting(fileLine.line);
     };
 
+    connect(settings, &Settings::sourceCodePathsChanged, this, [this](const QString&) { showDisassembly(); });
+
     connect(ui->assemblyView, &QTreeView::entered, this, updateFromDisassembly);
 
     connect(ui->sourceCodeView, &QTreeView::entered, this, updateFromSource);
@@ -353,9 +355,9 @@ void ResultsDisassemblyPage::showDisassembly()
     auto settings = Settings::instance();
     const auto colon = QLatin1Char(':');
 
-    showDisassembly(DisassemblyOutput::disassemble(objdump(), m_arch, settings->debugPaths().split(colon),
-                                                   settings->extraLibPaths().split(colon), settings->sourceCodePaths(),
-                                                   settings->sysroot(), curSymbol));
+    showDisassembly(DisassemblyOutput::disassemble(
+        objdump(), m_arch, settings->debugPaths().split(colon), settings->extraLibPaths().split(colon),
+        settings->sourceCodePaths().split(colon), settings->sysroot(), curSymbol));
 }
 
 void ResultsDisassemblyPage::showDisassembly(const DisassemblyOutput& disassemblyOutput)

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -185,8 +185,8 @@ void Settings::loadFromFile()
         sharedConfig->group("PathSettings").writeEntry("userPaths", this->userPaths());
         sharedConfig->group("PathSettings").writeEntry("systemPaths", this->systemPaths());
     });
-    m_sourceCodePaths = sharedConfig->group("PathSettings").readEntry("sourceCodePaths", QStringList());
-    connect(this, &Settings::sourceCodePathsChanged, this, [sharedConfig](const QStringList& paths) {
+    m_sourceCodePaths = sharedConfig->group("PathSettings").readEntry("sourceCodePaths", QString());
+    connect(this, &Settings::sourceCodePathsChanged, this, [sharedConfig](const QString& paths) {
         sharedConfig->group("PathSettings").writeEntry("sourceCodePaths", paths);
     });
 
@@ -227,7 +227,7 @@ void Settings::loadFromFile()
     });
 }
 
-void Settings::setSourceCodePaths(const QStringList& paths)
+void Settings::setSourceCodePaths(const QString& paths)
 {
     if (m_sourceCodePaths != paths) {
         m_sourceCodePaths = paths;

--- a/src/settings.h
+++ b/src/settings.h
@@ -139,7 +139,7 @@ public:
         return m_lastUsedEnvironment;
     }
 
-    QStringList sourceCodePaths() const
+    QString sourceCodePaths() const
     {
         return m_sourceCodePaths;
     }
@@ -163,7 +163,7 @@ signals:
     void objdumpChanged(const QString& objdump);
     void callgraphChanged();
     void lastUsedEnvironmentChanged(const QString& envName);
-    void sourceCodePathsChanged(const QStringList& paths);
+    void sourceCodePathsChanged(const QString& paths);
 
 public slots:
     void setPrettifySymbols(bool prettifySymbols);
@@ -184,7 +184,7 @@ public slots:
     void setCallgraphColors(const QColor& active, const QColor& inactive);
     void setCostAggregation(Settings::CostAggregation costAggregation);
     void setLastUsedEnvironment(const QString& envName);
-    void setSourceCodePaths(const QStringList& paths);
+    void setSourceCodePaths(const QString& paths);
 
 private:
     Settings() = default;
@@ -198,7 +198,6 @@ private:
     QStringList m_userPaths;
     QStringList m_systemPaths;
     QStringList m_debuginfodUrls;
-    QStringList m_sourceCodePaths;
 
     QString m_sysroot;
     QString m_kallsyms;
@@ -207,6 +206,7 @@ private:
     QString m_appPath;
     QString m_arch;
     QString m_objdump;
+    QString m_sourceCodePaths;
 
     QString m_lastUsedEnvironment;
 

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -297,11 +297,13 @@ void SettingsDialog::addSourcePathPage()
 
     sourcePathPage->setupUi(page);
 
+    const auto colon = QLatin1Char(':');
     connect(Settings::instance(), &Settings::sourceCodePathsChanged, this,
-            [this](const QStringList& paths) { sourcePathPage->sourcePaths->setItems(paths); });
+            [this, colon](const QString& paths) { sourcePathPage->sourcePaths->setItems(paths.split(colon)); });
 
     setupMultiPath(sourcePathPage->sourcePaths, sourcePathPage->label, buttonBox()->button(QDialogButtonBox::Ok));
 
-    connect(buttonBox(), &QDialogButtonBox::accepted, this,
-            [this] { Settings::instance()->setSourceCodePaths(sourcePathPage->sourcePaths->items()); });
+    connect(buttonBox(), &QDialogButtonBox::accepted, this, [this, colon] {
+        Settings::instance()->setSourceCodePaths(sourcePathPage->sourcePaths->items().join(colon));
+    });
 }


### PR DESCRIPTION
this patch add allows the user to add a custom source path which will overwrite the source path provided in the binary
this makes the disassembler, ... work if the source code directory was moved after creating the binary

closes: #418