### PR TITLE
add copy function to disassembly views

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,6 +54,7 @@ set(HOTSPOT_SRCS
     perfcontrolfifowrapper.cpp
     errnoutil.cpp
     recordhost.cpp
+    copyabletreeview.cpp
     # ui files:
     mainwindow.ui
     aboutdialog.ui

--- a/src/copyabletreeview.cpp
+++ b/src/copyabletreeview.cpp
@@ -1,0 +1,45 @@
+/*
+    SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
+    SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#include "copyabletreeview.h"
+
+#include <QClipboard>
+#include <QGuiApplication>
+#include <QKeyEvent>
+
+CopyableTreeView::CopyableTreeView(QWidget* parent)
+    : QTreeView(parent)
+{
+}
+
+CopyableTreeView::~CopyableTreeView() = default;
+
+void CopyableTreeView::keyPressEvent(QKeyEvent* event)
+{
+    if (event->matches(QKeySequence::Copy)) {
+        QString text;
+        const auto indexes = selectionModel()->selectedIndexes();
+
+        int row = indexes.isEmpty() ? 0 : indexes.first().row();
+        for (const auto& index : indexes) {
+            const auto content = index.data().toString();
+
+            // if both indexes are in the same row -> " " else add newline
+            if (index == indexes.first()) {
+                text = content;
+            } else if (row != index.row()) {
+                text += QLatin1Char('\n') + content;
+                row = index.row();
+            } else {
+                text += QLatin1Char(' ') + content;
+            }
+        }
+        QGuiApplication::clipboard()->setText(text);
+    } else {
+        QTreeView::keyPressEvent(event);
+    }
+}

--- a/src/copyabletreeview.h
+++ b/src/copyabletreeview.h
@@ -1,0 +1,21 @@
+/*
+    SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
+    SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#pragma once
+
+#include <QTreeView>
+
+class CopyableTreeView : public QTreeView
+{
+    Q_OBJECT
+public:
+    explicit CopyableTreeView(QWidget* parent = nullptr);
+    ~CopyableTreeView() override;
+
+protected:
+    void keyPressEvent(QKeyEvent* event) override;
+};

--- a/src/models/codedelegate.cpp
+++ b/src/models/codedelegate.cpp
@@ -58,7 +58,10 @@ void CodeDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, 
 
     bool ok = false;
     const auto sourceLine = index.data(m_lineNumberRole).toInt(&ok);
-    if (ok && sourceLine >= 0) {
+    if (option.state & QStyle::State_Selected) {
+        painter->setBrush(option.palette.highlight());
+        painter->drawRect(option.rect);
+    } else if (ok && sourceLine >= 0) {
         painter->setBrush(backgroundColor(sourceLine, index.data(m_highlightRole).toBool()));
         painter->drawRect(option.rect);
     }

--- a/src/models/codedelegate.cpp
+++ b/src/models/codedelegate.cpp
@@ -12,8 +12,7 @@
 #include <QPainter>
 #include <QTextLine>
 
-#include "disassemblymodel.h"
-#include "sourcecodemodel.h"
+Q_DECLARE_METATYPE(QTextLine)
 
 namespace {
 QColor backgroundColor(int line, bool isCurrent)

--- a/src/resultsdisassemblypage.ui
+++ b/src/resultsdisassemblypage.ui
@@ -142,9 +142,15 @@
         </widget>
        </item>
        <item>
-        <widget class="QTreeView" name="sourceCodeView">
+        <widget class="CopyableTreeView" name="sourceCodeView">
          <property name="alternatingRowColors">
           <bool>true</bool>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::ExtendedSelection</enum>
+         </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectItems</enum>
          </property>
          <property name="rootIsDecorated">
           <bool>false</bool>
@@ -304,9 +310,15 @@
         </widget>
        </item>
        <item>
-        <widget class="QTreeView" name="assemblyView">
+        <widget class="CopyableTreeView" name="assemblyView">
          <property name="alternatingRowColors">
           <bool>true</bool>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::ExtendedSelection</enum>
+         </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectItems</enum>
          </property>
          <property name="rootIsDecorated">
           <bool>false</bool>
@@ -449,6 +461,11 @@
    <class>KSqueezedTextLabel</class>
    <extends>QLabel</extends>
    <header>ksqueezedtextlabel.h</header>
+  </customwidget>
+  <customwidget>
+   <class>CopyableTreeView</class>
+   <extends>QTreeView</extends>
+   <header>copyabletreeview.h</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
This allows the user to copy text from the sourcecodeview and the disassembly view. This is done by reimplementing QTreeView with a custom keyPressEvent function that copies everything from selectionModel() to the clipboard and not just currentIndex like the default implementation does.