### PR TITLE
Update perfparser and use configure_file to generate config-perfparser.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,8 +140,6 @@ set_package_properties(
     TYPE OPTIONAL
 )
 
-feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
-
 include(KDEInstallDirs)
 include(KDECMakeSettings)
 include(ECMAddTests)
@@ -173,3 +171,4 @@ install(
     FILES com.kdab.Hotspot.appdata.xml
     DESTINATION ${KDE_INSTALL_METAINFODIR}
 )
+feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)


### PR DESCRIPTION
This also fixes the build error if libdebuginfod is installed but not libdebuginfo-devel, i.e. if debuginfod.h is missing.

Requires https://github.com/KDAB/perfparser/pull/29 to be merged first.