### PR TITLE
check if perf support libtraceevent

### DIFF
--- a/src/recordhost.cpp
+++ b/src/recordhost.cpp
@@ -130,9 +130,11 @@ RecordHost::PerfCapabilities fetchLocalPerfCapabilities(const QString& perfPath)
     const auto help = perfRecordHelp(perfPath);
     capabilities.canCompress = Zstd_FOUND && buildOptions.contains("zstd: [ on  ]");
     capabilities.canUseAio = buildOptions.contains("aio: [ on  ]");
+    capabilities.libtraceeventSupport = buildOptions.contains("libtraceevent: [ on  ]");
     capabilities.canSwitchEvents = help.contains("--switch-events");
     capabilities.canSampleCpu = help.contains("--sample-cpu");
-    capabilities.canProfileOffCpu = canTrace(QStringLiteral("events/sched/sched_switch"));
+    capabilities.canProfileOffCpu =
+        capabilities.libtraceeventSupport && canTrace(QStringLiteral("events/sched/sched_switch"));
 
     const auto isElevated = privsAlreadyElevated();
     capabilities.privilegesAlreadyElevated = isElevated;

--- a/src/recordhost.h
+++ b/src/recordhost.h
@@ -79,6 +79,7 @@ public:
         bool canCompress = false;
         bool canElevatePrivileges = false;
         bool privilegesAlreadyElevated = false;
+        bool libtraceeventSupport = false;
     };
     PerfCapabilities perfCapabilities() const
     {

--- a/src/recordpage.cpp
+++ b/src/recordpage.cpp
@@ -227,6 +227,14 @@ RecordPage::RecordPage(QWidget* parent)
                 ui->compressionComboBox->setVisible(capabilities.canCompress);
                 ui->compressionLabel->setVisible(capabilities.canCompress);
 
+                ui->offCpuCheckBox->setCheckable(capabilities.libtraceeventSupport);
+
+                if (!capabilities.libtraceeventSupport) {
+                    ui->offCpuCheckBox->setChecked(false);
+                    ui->offCpuCheckBox->setText(
+                        tr("perf doesn't support libtraceevent, you may need to build perf manually to support this"));
+                }
+
                 if (!capabilities.canElevatePrivileges) {
                     ui->elevatePrivilegesCheckBox->setChecked(false);
                     ui->elevatePrivilegesCheckBox->setEnabled(false);
@@ -441,7 +449,7 @@ RecordPage::RecordPage(QWidget* parent)
 
     auto updateOffCpuCheckboxState = [this](RecordHost::PerfCapabilities capabilities) {
         const bool enableOffCpuProfiling = (ui->elevatePrivilegesCheckBox->isChecked() || capabilities.canProfileOffCpu)
-            && capabilities.canSwitchEvents;
+            && capabilities.canSwitchEvents && capabilities.libtraceeventSupport;
 
         if (enableOffCpuProfiling == ui->offCpuCheckBox->isEnabled()) {
             return;


### PR DESCRIPTION
Some distros **cough** ubuntu **cough** build perf without libtraceevent support. In this case tracepoints obviosly don't work. This patch adds a check for this and shows the user an error message.

closes: #519