### PR TITLE
fix out of range access

### DIFF
--- a/src/models/search.h
+++ b/src/models/search.h
@@ -29,7 +29,7 @@ int search_impl(iter begin, iter end, iter current, SearchFunc searchFunc, EndRe
     if (begin == end)
         return -1;
 
-    auto start = current + 1;
+    const auto start = (current == end) ? begin : (current + 1);
     auto found = std::find_if(start, end, searchFunc);
 
     if (found != end) {

--- a/tests/modeltests/tst_search.cpp
+++ b/tests/modeltests/tst_search.cpp
@@ -82,6 +82,26 @@ private slots:
                      3);
         }
     }
+
+    void testArrayIsEmpty()
+    {
+        const std::array<int, 0> testArray;
+
+        for (int i = 0; i < 2; i++) {
+            QCOMPARE(search(
+                         testArray, i, Direction::Forward, [](int) { return true; }, [] {}),
+                     -1);
+        }
+    }
+
+    void testOutOfRangeIfCurrentIsEnd()
+    {
+        const std::array<int, 1> testArray = {0};
+
+        QCOMPARE(search(
+                     testArray, 1, Direction::Forward, [](int i) { return i == 0; }, [] {}),
+                 0);
+    }
 };
 
 QTEST_GUILESS_MAIN(TestSearch)


### PR DESCRIPTION
start was set to current + 1 which will cause undefined behavior if current is the last element
this patch adds a check for this and wraps around in that case

fixes: #526