### PR TITLE
use python 3.11 to run pre-commit on the ci

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,5 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.11.x
     - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
~the old pre-commit action broke and is no longer working I relpaced it with pre-commit-lite which support auto fixup~

python got updated to 3.12 which broke pre-commit