### PR TITLE
extend old binary filter instead of replacing it

### DIFF
--- a/src/models/filterandzoomstack.cpp
+++ b/src/models/filterandzoomstack.cpp
@@ -196,6 +196,9 @@ void FilterAndZoomStack::applyFilter(Data::FilterAction filter)
         filter.excludeSymbols += lastFilter.excludeSymbols;
         filter.includeSymbols += lastFilter.includeSymbols;
         filter.includeSymbols.subtract(filter.excludeSymbols);
+        filter.excludeBinaries += lastFilter.excludeBinaries;
+        filter.includeBinaries += lastFilter.includeBinaries;
+        filter.includeBinaries.subtract(filter.excludeBinaries);
     }
 
     m_filterStack.push_back(filter);


### PR DESCRIPTION
fixes #475

Nice to see that the work on #558 brought something more useful - an understanding how the context menu works and with that the option to debug the related issue :-)