### PR TITLE
Fix KF6 build

### DIFF
--- a/src/perfoutputwidgetkonsole.cpp
+++ b/src/perfoutputwidgetkonsole.cpp
@@ -149,7 +149,7 @@ void PerfOutputWidgetKonsole::addPartToLayout()
     m_konsoleFile = new QTemporaryFile(m_konsolePart);
     m_konsoleFile->open();
 
-    const auto terminalInterface = qobject_cast<TerminalInterfaceV2*>(m_konsolePart);
+    const auto terminalInterface = qobject_cast<TerminalInterface*>(m_konsolePart);
     terminalInterface->startProgram(tailExe(), {tailExe(), QStringLiteral("-f"), m_konsoleFile->fileName()});
 
     m_konsolePart->widget()->focusWidget()->installEventFilter(this);


### PR DESCRIPTION
TerminalInterfaceV2 was merged into TerminalInterface

Since Hotspot doesn't use any of the features of V2 we can just use TerminalInterface everywhere