### PR TITLE
exclude objdump.indexed_start_internal.txt from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
   rev: v4.3.0
   hooks:
   - id: trailing-whitespace
+    exclude: (tests/modeltests/disassembly/)
   - id: end-of-file-fixer
   - id: check-added-large-files
     args: ['--maxkb=1000']


### PR DESCRIPTION
pre-commit complains about trailing whitespaces, this is a false positive, since in this case they are part of the formatting