### PR TITLE
Disable disassembly of inline functions

### DIFF
--- a/src/flamegraph.cpp
+++ b/src/flamegraph.cpp
@@ -261,7 +261,7 @@ QString FrameGraphicsItem::description() const
         root = static_cast<const FrameGraphicsRootItem*>(item);
     }
 
-    auto symbol = Util::formatSymbol(m_symbol);
+    auto symbol = Util::formatSymbolExtended(m_symbol);
     if (root == this) {
         return symbol;
     }

--- a/src/flamegraph.cpp
+++ b/src/flamegraph.cpp
@@ -170,8 +170,29 @@ void FrameGraphicsItem::paint(QPainter* painter, const QStyleOptionGraphicsItem*
         auto noMatchColor = brush().color();
         noMatchColor.setAlpha(50);
         painter->fillRect(rect(), noMatchColor);
-    } else { // default, when no search is running, or a sub-item is matched
-        painter->fillRect(rect(), brush());
+    } else {
+        // default, when no search is running, or a sub-item is matched
+        auto background = brush();
+
+        // give inline frames a slightly different background color
+        if (m_symbol.isInline) {
+            auto color = background.color();
+            if (qGray(pen().color().rgb()) < 128) {
+                color = color.lighter();
+            } else {
+                color = color.darker();
+            }
+            background.setColor(color);
+        }
+        painter->fillRect(rect(), background);
+
+        // give inline frames a border with the normal background color
+        if (m_symbol.isInline) {
+            const auto oldPen = painter->pen();
+            painter->setPen(QPen(brush().color(), 0.));
+            painter->drawRect(rect().adjusted(-1, -1, -1, -1));
+            painter->setPen(oldPen);
+        }
     }
 
     const QPen oldPen = painter->pen();

--- a/src/models/data.h
+++ b/src/models/data.h
@@ -26,7 +26,7 @@ QString prettifySymbol(const QString& symbol);
 struct Symbol
 {
     Symbol(const QString& symbol = {}, quint64 relAddr = 0, quint64 size = 0, const QString& binary = {},
-           const QString& path = {}, const QString& actualPath = {}, bool isKernel = false)
+           const QString& path = {}, const QString& actualPath = {}, bool isKernel = false, bool isInline = false)
         : symbol(symbol)
         , prettySymbol(Data::prettifySymbol(symbol))
         , relAddr(relAddr)
@@ -35,6 +35,7 @@ struct Symbol
         , path(path)
         , actualPath(actualPath)
         , isKernel(isKernel)
+        , isInline(isInline)
     {
     }
 
@@ -53,6 +54,7 @@ struct Symbol
     // actual file path
     QString actualPath;
     bool isKernel = false;
+    bool isInline = false;
 
     bool operator<(const Symbol& rhs) const
     {
@@ -66,7 +68,7 @@ struct Symbol
 
     bool canDisassemble() const
     {
-        return !symbol.isEmpty() && !path.isEmpty() && relAddr > 0 && size > 0;
+        return !symbol.isEmpty() && !path.isEmpty() && relAddr > 0 && size > 0 && !isInline;
     }
 };
 

--- a/src/parsers/perf/perfparser.cpp
+++ b/src/parsers/perf/perfparser.cpp
@@ -228,12 +228,13 @@ struct Symbol
     StringId path;
     StringId actualPath;
     bool isKernel = false;
+    bool isInline = false;
 };
 
 QDataStream& operator>>(QDataStream& stream, Symbol& symbol)
 {
     return stream >> symbol.name >> symbol.binary >> symbol.path >> symbol.isKernel >> symbol.relAddr >> symbol.size
-        >> symbol.actualPath;
+        >> symbol.actualPath >> symbol.isInline;
 }
 
 QDebug operator<<(QDebug stream, const Symbol& symbol)
@@ -245,7 +246,8 @@ QDebug operator<<(QDebug stream, const Symbol& symbol)
                                << "binary=" << symbol.binary << ", "
                                << "path=" << symbol.path << ", "
                                << "actualPath=" << symbol.actualPath << ", "
-                               << "isKernel=" << symbol.isKernel << "}";
+                               << "isKernel=" << symbol.isKernel << ", "
+                               << "isInline=" << symbol.isInline << "}";
     return stream;
 }
 
@@ -1017,8 +1019,9 @@ public:
         const auto pathString = strings.value(symbol.symbol.path.id);
         const auto actualPathString = strings.value(symbol.symbol.actualPath.id);
         const auto isKernel = symbol.symbol.isKernel;
-        bottomUpResult.symbols[symbol.id] = {symbolString, relAddr,          size,    binaryString,
-                                             pathString,   actualPathString, isKernel};
+        const auto isInline = symbol.symbol.isInline;
+        bottomUpResult.symbols[symbol.id] = {symbolString, relAddr,          size,     binaryString,
+                                             pathString,   actualPathString, isKernel, isInline};
 
         // Count total and missing symbols per module for error report
         auto& numSymbols = numSymbolsByModule[symbol.symbol.binary.id];

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -91,7 +91,7 @@ std::pair<QString, QString> elideArguments(const QString& symbolText)
 QString formatForTooltip(const Data::Symbol& symbol)
 {
     return QCoreApplication::translate("Util", "symbol: <tt>%1</tt><br/>binary: <tt>%2</tt>")
-        .arg(Util::formatSymbol(symbol).toHtmlEscaped(), Util::formatString(symbol.binary));
+        .arg(Util::formatSymbolExtended(symbol).toHtmlEscaped(), Util::formatString(symbol.binary));
 }
 
 QString formatTooltipImpl(int id, const QString& text, const Data::Costs* selfCosts, const Data::Costs* inclusiveCosts)
@@ -264,6 +264,15 @@ QString Util::formatSymbol(const Data::Symbol& symbol, bool replaceEmptyString)
     }
 
     return formatString(symbolString, replaceEmptyString);
+}
+
+QString Util::formatSymbolExtended(const Data::Symbol& symbol)
+{
+    auto ret = formatSymbol(symbol);
+    if (symbol.isInline) {
+        ret = QCoreApplication::translate("Util", "%1 (inlined)").arg(ret);
+    }
+    return ret;
 }
 
 QString Util::formatCost(quint64 cost)

--- a/src/util.h
+++ b/src/util.h
@@ -53,6 +53,7 @@ struct HashCombine
 
 QString formatString(const QString& input, bool replaceEmptyString = true);
 QString formatSymbol(const Data::Symbol& symbol, bool replaceEmptyString = true);
+QString formatSymbolExtended(const Data::Symbol& symbol);
 QString formatCost(quint64 cost);
 QString formatCostRelative(quint64 selfCost, quint64 totalCost, bool addPercentSign = false);
 QString formatTimeString(quint64 nanoseconds, bool shortForm = false);

--- a/tests/modeltests/tst_disassemblyoutput.cpp
+++ b/tests/modeltests/tst_disassemblyoutput.cpp
@@ -357,6 +357,32 @@ private slots:
         }
     }
 
+    void testCanDisassemble_data()
+    {
+        QTest::addColumn<Data::Symbol>("symbol");
+        QTest::addColumn<bool>("canDisassemble");
+
+        QTest::newRow("normal symbol") << Data::Symbol(QStringLiteral("main"), 0x1159, 0x32805, {},
+                                                       QStringLiteral("/some/path"), {}, false, false)
+                                       << true;
+        QTest::newRow("relocated symbol")
+            << Data::Symbol(QStringLiteral("printf"), 0, 0, {}, QStringLiteral("/some/path"), {}, false, false)
+            << false;
+        QTest::newRow("inlined symbol") << Data::Symbol(QStringLiteral("main::memcpy"), 0x1159, 0x32805, {},
+                                                        QStringLiteral("/some/path"), {}, false, true)
+                                        << false;
+        QTest::newRow("unkown binary") << Data::Symbol(QStringLiteral("main"), 0x1159, 0x32805, {}, {}, {}, false,
+                                                       false)
+                                       << false;
+    }
+
+    void testCanDisassemble()
+    {
+        QFETCH(Data::Symbol, symbol);
+        QFETCH(bool, canDisassemble);
+        QCOMPARE(symbol.canDisassemble(), canDisassemble);
+    }
+
 private:
     struct FunctionData
     {


### PR DESCRIPTION
Currently this doesn't work correctly. In the flamegraph the top entry doesn't has the inline flag set.
![grafik](https://github.com/KDAB/hotspot/assets/82457690/72f7559b-f1c1-4990-acc6-f289c66b8949)
