### PR TITLE
[enhancement] cut 60% time for PerfParser::filterResults

### DIFF
--- a/src/callgraphgenerator.cpp
+++ b/src/callgraphgenerator.cpp
@@ -25,10 +25,10 @@ QHash<Data::Symbol, QString> writeGraph(QTextStream& stream, const Data::Symbol&
            << "\"]\n";
 
     stream << "node" << parentId << " [label=\"";
-    if (symbol.prettySymbol.isEmpty()) {
+    if (symbol.prettySymbol().isEmpty()) {
         stream << "??";
     } else {
-        stream << symbol.prettySymbol;
+        stream << symbol.prettySymbol();
     }
     stream << "\", color=\"" << settings->callgraphActiveColor().name() << "\"]\n";
 
@@ -52,7 +52,7 @@ void resultsToDot(int height, Direction direction, const Data::Symbol& symbol, c
         return;
     }
 
-    if (symbol.prettySymbol.isEmpty())
+    if (symbol.prettySymbol().isEmpty())
         return;
 
     if (results.selfCosts.numTypes() == 0) {
@@ -85,7 +85,7 @@ void resultsToDot(int height, Direction direction, const Data::Symbol& symbol, c
         auto idIt = nodeIdLookup.find(key);
         if (idIt == nodeIdLookup.end()) {
             idIt = nodeIdLookup.insert(key, QUuid::createUuid().toString(QUuid::Id128));
-            addNode(idIt.value(), key.prettySymbol.isEmpty() ? QStringLiteral("??") : key.prettySymbol);
+            addNode(idIt.value(), key.prettySymbol().isEmpty() ? QStringLiteral("??") : key.prettySymbol());
         }
         const auto nodeId = idIt.value();
 

--- a/src/models/callercalleemodel.cpp
+++ b/src/models/callercalleemodel.cpp
@@ -82,9 +82,9 @@ QVariant CallerCalleeModel::cell(int column, int role, const Data::Symbol& symbo
     } else if (role == SortRole) {
         switch (column) {
         case Symbol:
-            return Util::formatSymbol(symbol.prettySymbol);
+            return Util::formatSymbol(symbol.prettySymbol());
         case Binary:
-            return symbol.binary;
+            return symbol.binary();
         }
         column -= NUM_BASE_COLUMNS;
         if (column < m_results.selfCosts.numTypes()) {
@@ -105,7 +105,7 @@ QVariant CallerCalleeModel::cell(int column, int role, const Data::Symbol& symbo
         case Symbol:
             return Util::formatSymbol(symbol);
         case Binary:
-            return symbol.binary;
+            return symbol.binary();
         }
         column -= 2;
         if (column < m_results.selfCosts.numTypes()) {

--- a/src/models/callercalleemodel.h
+++ b/src/models/callercalleemodel.h
@@ -141,7 +141,7 @@ public:
             case Symbol:
                 return Util::formatSymbol(symbol);
             case Binary:
-                return symbol.binary;
+                return symbol.binary();
             }
             return costs[column - NUM_BASE_COLUMNS];
         } else if (role == TotalCostRole && column >= NUM_BASE_COLUMNS) {
@@ -151,7 +151,7 @@ public:
             case Symbol:
                 return Util::formatSymbol(symbol);
             case Binary:
-                return symbol.binary;
+                return symbol.binary();
             }
             return Util::formatCostRelative(costs[column - NUM_BASE_COLUMNS],
                                             m_costs.totalCost(column - NUM_BASE_COLUMNS), true);

--- a/src/models/callercalleeproxy.cpp
+++ b/src/models/callercalleeproxy.cpp
@@ -25,7 +25,7 @@ bool match(const QSortFilterProxyModel* proxy, const Data::Symbol& symbol)
 {
     const auto pattern = proxy->filterRegularExpression();
 
-    return matchImpl(pattern, symbol.symbol) || matchImpl(pattern, symbol.binary);
+    return matchImpl(pattern, symbol.symbol()) || matchImpl(pattern, symbol.binary());
 }
 
 bool match(const QSortFilterProxyModel* proxy, const Data::FileLine& fileLine)

--- a/src/models/data.cpp
+++ b/src/models/data.cpp
@@ -262,7 +262,7 @@ void buildPerLibrary(const TopDown* node, PerLibraryResults& results, QHash<QStr
                      const Costs& costs)
 {
     for (const auto& child : node->children) {
-        const auto path = child.symbol.path;
+        const auto path = child.symbol.path();
 
         auto resultIndexIt = pathToResultIndex.find(path);
         if (resultIndexIt == pathToResultIndex.end()) {
@@ -270,8 +270,8 @@ void buildPerLibrary(const TopDown* node, PerLibraryResults& results, QHash<QStr
 
             PerLibrary library;
             library.id = *resultIndexIt;
-            library.symbol = Symbol({}, 0, 0, child.symbol.binary, child.symbol.path, child.symbol.actualPath,
-                                    child.symbol.isKernel);
+            library.symbol = Symbol({}, 0, 0, child.symbol.binary(), child.symbol.path(), child.symbol.actualPath(),
+                                    child.symbol.isKernel());
             results.root.children.push_back(library);
         }
 
@@ -339,10 +339,10 @@ void Data::callerCalleesFromBottomUpData(const BottomUpResults& bottomUpData, Ca
 QDebug Data::operator<<(QDebug stream, const Symbol& symbol)
 {
     stream.noquote().nospace() << "Symbol{"
-                               << "symbol=" << symbol.symbol << ", "
-                               << "relAddr=" << symbol.relAddr << ", "
-                               << "size=" << symbol.size << ", "
-                               << "binary=" << symbol.binary << "}";
+                               << "symbol=" << symbol.symbol() << ", "
+                               << "relAddr=" << symbol.relAddr() << ", "
+                               << "size=" << symbol.size() << ", "
+                               << "binary=" << symbol.binary() << "}";
     return stream.resetFormat().space();
 }
 

--- a/src/models/disassemblyoutput.cpp
+++ b/src/models/disassemblyoutput.cpp
@@ -84,8 +84,8 @@ QString findInSubdirRecursive(const QString& path, const QString& filename)
 QString findBinaryForSymbol(const QStringList& debugPaths, const QStringList& extraLibPaths, const Data::Symbol& symbol)
 {
     // file in .debug
-    if (QFileInfo::exists(symbol.actualPath)) {
-        return symbol.actualPath;
+    if (QFileInfo::exists(symbol.actualPath())) {
+        return symbol.actualPath();
     }
 
     auto findBinary = [](const QStringList& paths, const QString& binary) -> QString {
@@ -98,17 +98,17 @@ QString findBinaryForSymbol(const QStringList& debugPaths, const QStringList& ex
         return {};
     };
 
-    auto result = findBinary(debugPaths, symbol.binary);
+    auto result = findBinary(debugPaths, symbol.binary());
     if (!result.isEmpty())
         return result;
 
-    result = findBinary(extraLibPaths, symbol.binary);
+    result = findBinary(extraLibPaths, symbol.binary());
     if (!result.isEmpty())
         return result;
 
     // disassemble the binary if no debug file was found
-    if (QFileInfo::exists(symbol.path)) {
-        return symbol.path;
+    if (QFileInfo::exists(symbol.path())) {
+        return symbol.path();
     }
 
     return {};
@@ -276,7 +276,7 @@ DisassemblyOutput DisassemblyOutput::disassemble(const QString& objdump, const Q
 {
     DisassemblyOutput disassemblyOutput;
     disassemblyOutput.symbol = symbol;
-    if (symbol.symbol.isEmpty()) {
+    if (symbol.symbol().isEmpty()) {
         disassemblyOutput.errorMessage =
             QApplication::translate("DisassemblyOutput",
                                     "<qt>Empty symbol <tt>"
@@ -284,10 +284,10 @@ DisassemblyOutput DisassemblyOutput::disassemble(const QString& objdump, const Q
                                     "</tt> is selected.");
         return disassemblyOutput;
     }
-    if (symbol.relAddr == 0 || symbol.size == 0) {
+    if (symbol.relAddr() == 0 || symbol.size() == 0) {
         disassemblyOutput.errorMessage =
             QApplication::translate("DisassemblyOutput", "<qt>Symbol <tt>%1</tt> with unknown details is selected.")
-                .arg(symbol.symbol);
+                .arg(symbol.symbol());
         return disassemblyOutput;
     }
 
@@ -317,9 +317,9 @@ DisassemblyOutput DisassemblyOutput::disassemble(const QString& objdump, const Q
                                   QStringLiteral("-l"), // include source code lines
                                   QStringLiteral("-C"), // demangle names
                                   QStringLiteral("--start-address"),
-                                  toHex(symbol.relAddr),
+                                  toHex(symbol.relAddr()),
                                   QStringLiteral("--stop-address"),
-                                  toHex(symbol.relAddr + symbol.size)};
+                                  toHex(symbol.relAddr() + symbol.size())};
 
     // only available for objdump 2.34+
     if (canVisualizeJumps(processPath))
@@ -330,7 +330,7 @@ DisassemblyOutput DisassemblyOutput::disassemble(const QString& objdump, const Q
     auto binary = findBinaryForSymbol(debugPaths, extraLibPaths, symbol);
     if (binary.isEmpty()) {
         disassemblyOutput.errorMessage +=
-            QApplication::translate("DisassemblyOutput", "<qt>Could not find binary <tt>%1</tt>.").arg(symbol.binary);
+            QApplication::translate("DisassemblyOutput", "<qt>Could not find binary <tt>%1</tt>.").arg(symbol.binary());
         return disassemblyOutput;
     }
     arguments.append(binary);

--- a/src/models/sourcecodemodel.cpp
+++ b/src/models/sourcecodemodel.cpp
@@ -119,7 +119,7 @@ void SourceCodeModel::setDisassembly(const DisassemblyOutput& disassemblyOutput,
     Q_ASSERT(minLineNumber > 0);
     Q_ASSERT(minLineNumber < maxLineNumber);
 
-    m_prettySymbol = disassemblyOutput.symbol.prettySymbol;
+    m_prettySymbol = disassemblyOutput.symbol.prettySymbol();
     m_startLine = minLineNumber - 1; // convert to index
     m_numLines = maxLineNumber - minLineNumber + 1; // include minLineNumber
 

--- a/src/models/treemodel.cpp
+++ b/src/models/treemodel.cpp
@@ -69,7 +69,7 @@ QVariant BottomUpModel::rowData(const Data::BottomUp* row, int column, int role)
         case Symbol:
             return Util::formatSymbol(row->symbol);
         case Binary:
-            return row->symbol.binary;
+            return row->symbol.binary();
         }
         if (role == SortRole) {
             return m_results.costs.cost(column - NUM_BASE_COLUMNS, row->id);
@@ -161,7 +161,7 @@ QVariant TopDownModel::rowData(const Data::TopDown* row, int column, int role) c
         case Symbol:
             return Util::formatSymbol(row->symbol);
         case Binary:
-            return row->symbol.binary;
+            return row->symbol.binary();
         }
 
         column -= NUM_BASE_COLUMNS;
@@ -229,7 +229,7 @@ QVariant PerLibraryModel::rowData(const Data::PerLibrary* row, int column, int r
     if (role == Qt::DisplayRole || role == SortRole) {
         switch (column) {
         case Binary:
-            return Util::formatString(row->symbol.binary);
+            return Util::formatString(row->symbol.binary());
         }
 
         column -= NUM_BASE_COLUMNS;

--- a/src/parsers/perf/perfparser.cpp
+++ b/src/parsers/perf/perfparser.cpp
@@ -1152,8 +1152,8 @@ public:
             if (perfScriptOutput) {
                 *perfScriptOutput << '\t' << Qt::hex << qSetFieldWidth(16) << location.address << qSetFieldWidth(0)
                                   << Qt::dec << ' '
-                                  << (symbol.symbol.isEmpty() ? QStringLiteral("[unknown]") : symbol.symbol) << " ("
-                                  << symbol.binary << ")\n";
+                                  << (symbol.symbol().isEmpty() ? QStringLiteral("[unknown]") : symbol.symbol()) << " ("
+                                  << symbol.binary() << ")\n";
             }
         };
 
@@ -1766,11 +1766,11 @@ void PerfParser::filterResults(const Data::FilterAction& filter)
                                 }
                                 includedSymbols.remove(symbol);
 
-                                excluded = filter.excludeBinaries.contains(symbol.binary);
+                                excluded = filter.excludeBinaries.contains(symbol.binary());
                                 if (excluded) {
                                     return false;
                                 }
-                                includedBinaries.remove(symbol.binary);
+                                includedBinaries.remove(symbol.binary());
 
                                 // only stop when we included everything and no exclude filter is
                                 // set

--- a/src/resultsbottomuppage.cpp
+++ b/src/resultsbottomuppage.cpp
@@ -31,8 +31,8 @@ void stackCollapsedExport(QTextStream& file, int type, const Data::Costs& costs,
 
     auto entry = &node;
     while (entry) {
-        if (entry->symbol.symbol.isEmpty())
-            file << '[' << entry->symbol.binary << ']';
+        if (entry->symbol.symbol().isEmpty())
+            file << '[' << entry->symbol.binary() << ']';
         else
             file << Util::formatSymbol(entry->symbol);
         entry = entry->parent;

--- a/src/resultscallercalleepage.cpp
+++ b/src/resultscallercalleepage.cpp
@@ -204,7 +204,7 @@ ResultsCallerCalleePage::toSourceMapLocation(const Data::FileLine& fileLine, con
 
     // also try to resolve paths relative to the module output folder
     // fixes a common issue with qmake builds that use relative paths
-    const QString modulePath = QFileInfo(symbol.path).path() + QLatin1Char('/');
+    const QString modulePath = QFileInfo(symbol.path()).path() + QLatin1Char('/');
 
     resolvePath(m_sysroot) || resolvePath(m_sysroot + modulePath) || resolvePath(m_appPath)
         || resolvePath(m_appPath + modulePath);
@@ -292,6 +292,6 @@ void ResultsCallerCalleePage::openEditor(const Data::Symbol& symbol)
 
     if (it == map.keyEnd()) {
         emit navigateToCodeFailed(
-            tr("Failed to find location for symbol %1 in %2.").arg(symbol.prettySymbol, symbol.binary));
+            tr("Failed to find location for symbol %1 in %2.").arg(symbol.prettySymbol(), symbol.binary()));
     }
 }

--- a/src/resultsdisassemblypage.cpp
+++ b/src/resultsdisassemblypage.cpp
@@ -308,13 +308,13 @@ ResultsDisassemblyPage::ResultsDisassemblyPage(CostContextMenu* costContextMenu,
 
         const auto functionOffset = index.data(DisassemblyModel::LinkedFunctionOffsetRole).toInt();
 
-        if (m_symbolStack[m_stackIndex].symbol == functionName) {
+        if (m_symbolStack[m_stackIndex].symbol() == functionName) {
             ui->assemblyView->scrollTo(m_disassemblyModel->findIndexWithOffset(functionOffset),
                                        QAbstractItemView::ScrollHint::PositionAtTop);
         } else {
             const auto symbol =
                 std::find_if(m_callerCalleeResults.entries.keyBegin(), m_callerCalleeResults.entries.keyEnd(),
-                             [functionName](const Data::Symbol& symbol) { return symbol.symbol == functionName; });
+                             [functionName](const Data::Symbol& symbol) { return symbol.symbol() == functionName; });
 
             if (symbol != m_callerCalleeResults.entries.keyEnd()) {
                 m_symbolStack.push_back(*symbol);
@@ -347,7 +347,7 @@ ResultsDisassemblyPage::ResultsDisassemblyPage(CostContextMenu* costContextMenu,
         ui->stackBackButton->setEnabled(m_stackIndex > 0);
         ui->stackNextButton->setEnabled(m_stackIndex < m_symbolStack.size() - 1);
 
-        ui->stackEntry->setText(m_symbolStack[m_stackIndex].prettySymbol);
+        ui->stackEntry->setText(m_symbolStack[m_stackIndex].prettySymbol());
 
         showDisassembly();
     });
@@ -531,7 +531,7 @@ void ResultsDisassemblyPage::showDisassembly()
     const auto& curSymbol = m_symbolStack[m_stackIndex];
 
     // Show empty tab when selected symbol is not valid
-    if (curSymbol.symbol.isEmpty()) {
+    if (curSymbol.symbol().isEmpty()) {
         clear();
     }
 

--- a/src/resultsutil.cpp
+++ b/src/resultsutil.cpp
@@ -67,7 +67,7 @@ void addFilterActions(QMenu* menu, const Data::Symbol& symbol, FilterAndZoomStac
         auto filterActions = filterStack->actions();
 
         // don't include symbol-related entries for binary-only symbols (like in Top Hotspots Per File)
-        if (!symbol.symbol.isEmpty()) {
+        if (!symbol.symbol().isEmpty()) {
             auto symbolFilter = QVariant::fromValue(symbol);
 
             filterActions.filterInBySymbol->setData(symbolFilter);
@@ -79,8 +79,8 @@ void addFilterActions(QMenu* menu, const Data::Symbol& symbol, FilterAndZoomStac
         }
 
         // don't include binary-related entries when we don't have this information
-        if (!symbol.binary.isEmpty()) {
-            auto binaryFilter = QVariant::fromValue(symbol.binary);
+        if (!symbol.binary().isEmpty()) {
+            auto binaryFilter = QVariant::fromValue(symbol.binary());
 
             filterActions.filterInByBinary->setData(binaryFilter);
             filterActions.filterOutByBinary->setData(binaryFilter);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -91,7 +91,7 @@ std::pair<QString, QString> elideArguments(const QString& symbolText)
 QString formatForTooltip(const Data::Symbol& symbol)
 {
     return QCoreApplication::translate("Util", "symbol: <tt>%1</tt><br/>binary: <tt>%2</tt>")
-        .arg(Util::formatSymbol(symbol).toHtmlEscaped(), Util::formatString(symbol.binary));
+        .arg(Util::formatSymbol(symbol).toHtmlEscaped(), Util::formatString(symbol.binary()));
 }
 
 QString formatTooltipImpl(int id, const QString& text, const Data::Costs* selfCosts, const Data::Costs* inclusiveCosts)
@@ -258,7 +258,7 @@ QString Util::formatString(const QString& input, bool replaceEmptyString)
 
 QString Util::formatSymbol(const Data::Symbol& symbol, bool replaceEmptyString)
 {
-    QString symbolString = Settings::instance()->prettifySymbols() ? symbol.prettySymbol : symbol.symbol;
+    QString symbolString = Settings::instance()->prettifySymbols() ? symbol.prettySymbol() : symbol.symbol();
     if (Settings::instance()->collapseTemplates()) {
         symbolString = collapseTemplate(symbolString, Settings::instance()->collapseDepth());
     }
@@ -347,7 +347,7 @@ QString Util::formatFrequency(quint64 occurrences, quint64 nanoseconds)
 
 QString Util::formatBinaryTooltip(int id, const Data::Symbol& symbol, const Data::Costs& costs)
 {
-    return formatTooltipImpl(id, Util::formatString(symbol.binary), nullptr, &costs);
+    return formatTooltipImpl(id, Util::formatString(symbol.binary()), nullptr, &costs);
 }
 
 QString Util::formatTooltip(int id, const Data::Symbol& symbol, const Data::Costs& costs)

--- a/tests/integrationtests/tst_perfparser.cpp
+++ b/tests/integrationtests/tst_perfparser.cpp
@@ -34,9 +34,9 @@ namespace {
 template<typename T>
 bool searchForChildSymbol(const T& root, const QString& searchString, bool exact = true)
 {
-    if (exact && root.symbol.symbol == searchString) {
+    if (exact && root.symbol.symbol() == searchString) {
         return true;
-    } else if (!exact && root.symbol.symbol.contains(searchString)) {
+    } else if (!exact && root.symbol.symbol().contains(searchString)) {
         return true;
     } else {
         for (const auto& entry : root.children) {
@@ -107,7 +107,7 @@ struct ComparableSymbol
         VERIFY_OR_THROW(isPattern != rhs.isPattern);
         auto cmp = [](const Data::Symbol& symbol, const QVector<QPair<QString, QString>>& pattern) {
             return std::any_of(pattern.begin(), pattern.end(), [&symbol](const QPair<QString, QString>& pattern) {
-                return symbol.symbol.contains(pattern.first) && symbol.binary.contains(pattern.second);
+                return symbol.symbol().contains(pattern.first) && symbol.binary().contains(pattern.second);
             });
         };
         return isPattern ? cmp(rhs.symbol, pattern) : cmp(symbol, rhs.pattern);
@@ -127,8 +127,8 @@ char* toString(const ComparableSymbol& symbol)
         return QTest::toString(
             QString(QLatin1String("ComparableSymbol{[") + patterns.join(QLatin1String(", ")) + QLatin1String("]}")));
     } else {
-        return QTest::toString(QString(QLatin1String("ComparableSymbol{") + symbol.symbol.symbol + QLatin1String(", ")
-                                       + symbol.symbol.binary + QLatin1Char('}')));
+        return QTest::toString(QString(QLatin1String("ComparableSymbol{") + symbol.symbol.symbol() + QLatin1String(", ")
+                                       + symbol.symbol.binary() + QLatin1Char('}')));
     }
 }
 
@@ -148,7 +148,7 @@ ComparableSymbol cppRecursionTopSymbol(const QString& binary = QStringLiteral("c
 
 void dump(const Data::BottomUp& bottomUp, QTextStream& stream, const QByteArray& prefix)
 {
-    stream << prefix << bottomUp.symbol.symbol << '\n';
+    stream << prefix << bottomUp.symbol.symbol() << '\n';
 
     for (const auto& child : bottomUp.children) {
         dump(child, stream, prefix + '\t');

--- a/tests/modeltests/tst_callgraphgenerator.cpp
+++ b/tests/modeltests/tst_callgraphgenerator.cpp
@@ -25,7 +25,7 @@ private slots:
 
         auto key = Data::Symbol();
         for (auto it = results.entries.cbegin(); it != results.entries.cend(); it++) {
-            if (it.key().symbol == QLatin1String("test")) {
+            if (it.key().symbol() == QLatin1String("test")) {
                 key = it.key();
                 break;
             }
@@ -53,7 +53,7 @@ private slots:
 
         auto key = Data::Symbol();
         for (auto it = results.entries.cbegin(); it != results.entries.cend(); it++) {
-            if (it.key().symbol == QLatin1String("test")) {
+            if (it.key().symbol() == QLatin1String("test")) {
                 key = it.key();
                 break;
             }

--- a/tests/modeltests/tst_disassemblyoutput.cpp
+++ b/tests/modeltests/tst_disassemblyoutput.cpp
@@ -63,8 +63,9 @@ private slots:
     {
         QFETCH(Data::Symbol, symbol);
 
-        const auto actualBinaryFile = QFINDTESTDATA(symbol.binary);
-        symbol.actualPath = actualBinaryFile;
+        const auto actualBinaryFile = QFINDTESTDATA(symbol.binary());
+        symbol = Data::Symbol(symbol.symbol(), symbol.relAddr(), symbol.size(), symbol.binary(), symbol.path(),
+                              actualBinaryFile, symbol.isKernel());
 
         QVERIFY(!actualBinaryFile.isEmpty() && QFile::exists(actualBinaryFile));
         const auto actualOutputFile = QString(actualBinaryFile + QLatin1String(".actual.txt"));

--- a/tests/modeltests/tst_models.cpp
+++ b/tests/modeltests/tst_models.cpp
@@ -136,19 +136,19 @@ private slots:
         )");
         QCOMPARE(tree.root.children.size(), 3);
         const auto i1 = &tree.root.children.first();
-        QCOMPARE(i1->symbol.symbol, QStringLiteral("1"));
+        QCOMPARE(i1->symbol.symbol(), QStringLiteral("1"));
         QCOMPARE(i1->children.size(), 1);
         const auto i2 = &i1->children.first();
-        QCOMPARE(i2->symbol.symbol, QStringLiteral("2"));
+        QCOMPARE(i2->symbol.symbol(), QStringLiteral("2"));
         QCOMPARE(i2->children.size(), 1);
         const auto i3 = &i2->children.first();
-        QCOMPARE(i3->symbol.symbol, QStringLiteral("3"));
+        QCOMPARE(i3->symbol.symbol(), QStringLiteral("3"));
         QCOMPARE(i3->children.size(), 2);
         const auto i4 = &i3->children.first();
-        QCOMPARE(i4->symbol.symbol, QStringLiteral("4"));
+        QCOMPARE(i4->symbol.symbol(), QStringLiteral("4"));
         QCOMPARE(i4->children.size(), 0);
         const auto i5 = &i3->children.last();
-        QCOMPARE(i5->symbol.symbol, QStringLiteral("5"));
+        QCOMPARE(i5->symbol.symbol(), QStringLiteral("5"));
         QCOMPARE(i5->children.size(), 0);
 
         BottomUpModel model;
@@ -337,8 +337,9 @@ private slots:
     {
         QFETCH(Data::Symbol, symbol);
 
-        const auto actualBinaryFile = QFINDTESTDATA(symbol.binary);
-        symbol.actualPath = actualBinaryFile;
+        const auto actualBinaryFile = QFINDTESTDATA(symbol.binary());
+        symbol = Data::Symbol(symbol.symbol(), symbol.relAddr(), symbol.size(), symbol.binary(), symbol.path(),
+                              actualBinaryFile, symbol.isKernel());
 
         const auto tree = generateTree1();
 
@@ -382,8 +383,9 @@ private slots:
     {
         QFETCH(Data::Symbol, symbol);
 
-        const auto actualBinaryFile = QFINDTESTDATA(symbol.binary);
-        symbol.actualPath = actualBinaryFile;
+        const auto actualBinaryFile = QFINDTESTDATA(symbol.binary());
+        symbol = Data::Symbol(symbol.symbol(), symbol.relAddr(), symbol.size(), symbol.binary(), symbol.path(),
+                              actualBinaryFile, symbol.isKernel());
 
         const auto tree = generateTree1();
 
@@ -775,7 +777,7 @@ private slots:
         QFETCH(QString, prettySymbol);
         QFETCH(QString, symbol);
 
-        QCOMPARE(Data::Symbol(symbol).prettySymbol, prettySymbol);
+        QCOMPARE(Data::Symbol(symbol).prettySymbol(), prettySymbol);
     }
 
     void testCollapseTemplates_data()

--- a/tests/testutils.h
+++ b/tests/testutils.h
@@ -62,7 +62,7 @@ void printTree(const Tree& tree, const Results& results, QStringList* entries, i
     QString indent;
     indent.fill(QLatin1Char(' '), indentLevel);
     for (const auto& entry : tree.children) {
-        entries->push_back(indent + entry.symbol.symbol + QLatin1Char('=') + printCost(entry, results));
+        entries->push_back(indent + entry.symbol.symbol() + QLatin1Char('=') + printCost(entry, results));
         printTree(entry, results, entries, indentLevel + 1);
     }
 }
@@ -95,16 +95,16 @@ inline QStringList printMap(const Data::CallerCalleeResults& results)
     for (auto it = results.entries.begin(), end = results.entries.end(); it != end; ++it) {
         VERIFY_OR_THROW(!ids.contains(it->id));
         ids.insert(it->id);
-        list.push_back(it.key().symbol + QLatin1Char('=') + printCost(it.value(), results));
+        list.push_back(it.key().symbol() + QLatin1Char('=') + printCost(it.value(), results));
         QStringList subList;
         for (auto callersIt = it->callers.begin(), callersEnd = it->callers.end(); callersIt != callersEnd;
              ++callersIt) {
-            subList.push_back(it.key().symbol + QLatin1Char('<') + callersIt.key().symbol + QLatin1Char('=')
+            subList.push_back(it.key().symbol() + QLatin1Char('<') + callersIt.key().symbol() + QLatin1Char('=')
                               + QString::number(callersIt.value()[0]));
         }
         for (auto calleesIt = it->callees.begin(), calleesEnd = it->callees.end(); calleesIt != calleesEnd;
              ++calleesIt) {
-            subList.push_back(it.key().symbol + QLatin1Char('>') + calleesIt.key().symbol + QLatin1Char('=')
+            subList.push_back(it.key().symbol() + QLatin1Char('>') + calleesIt.key().symbol() + QLatin1Char('=')
                               + QString::number(calleesIt.value()[0]));
         }
         subList.sort();
@@ -130,12 +130,12 @@ inline QStringList printCallerCalleeModel(const CallerCalleeModel& model)
         QStringList subList;
         const auto& callers = symbolIndex.data(CallerCalleeModel::CallersRole).value<Data::CallerMap>();
         for (auto callersIt = callers.begin(), callersEnd = callers.end(); callersIt != callersEnd; ++callersIt) {
-            subList.push_back(symbol + QLatin1Char('<') + callersIt.key().symbol + QLatin1Char('=')
+            subList.push_back(symbol + QLatin1Char('<') + callersIt.key().symbol() + QLatin1Char('=')
                               + QString::number(callersIt.value()[0]));
         }
         const auto& callees = symbolIndex.data(CallerCalleeModel::CalleesRole).value<Data::CalleeMap>();
         for (auto calleesIt = callees.begin(), calleesEnd = callees.end(); calleesIt != calleesEnd; ++calleesIt) {
-            subList.push_back(symbol + QLatin1Char('>') + calleesIt.key().symbol + QLatin1Char('=')
+            subList.push_back(symbol + QLatin1Char('>') + calleesIt.key().symbol() + QLatin1Char('=')
                               + QString::number(calleesIt.value()[0]));
         }
         subList.sort();


### PR DESCRIPTION
When change to "aggregate cost by symbol", filterResults spends a lot of time doing string comparison. This patch will reduce it dramatically.

Test on a 240MB perf.data/6 core CPU. The time of switching to "aggregate cost by symbol" is reduced from 50.x seconds to 19.x seconds.