### PR TITLE
CallerCallee add jump to source location in disassembly

### DIFF
--- a/src/resultscallercalleepage.h
+++ b/src/resultscallercalleepage.h
@@ -47,12 +47,12 @@ public:
 
 private slots:
     void onSourceMapContextMenu(QPoint pos);
-    void onSourceMapActivated(const QModelIndex& index);
 
 signals:
     void navigateToCode(const QString& url, int lineNumber, int columnNumber);
     void navigateToCodeFailed(const QString& message);
     void selectSymbol(const Data::Symbol& symbol);
+    void jumpToSourceCode(const Data::Symbol& symbol, const Data::FileLine& line);
     void jumpToDisassembly(const Data::Symbol& symbol);
 
 private:

--- a/src/resultsdisassemblypage.cpp
+++ b/src/resultsdisassemblypage.cpp
@@ -641,4 +641,12 @@ void ResultsDisassemblyPage::changeEvent(QEvent* event)
     }
 }
 
+void ResultsDisassemblyPage::jumpToSourceLine(const Data::FileLine& line)
+{
+    if (line.isValid()) {
+        ui->sourceCodeView->scrollTo(m_sourceCodeModel->indexForFileLine(line));
+        ui->assemblyView->scrollTo(m_disassemblyModel->indexForFileLine(line));
+    }
+}
+
 #include "resultsdisassemblypage.moc"

--- a/src/resultsdisassemblypage.h
+++ b/src/resultsdisassemblypage.h
@@ -52,6 +52,8 @@ public:
     void setObjdump(const QString& objdump);
     void setArch(const QString& arch);
 
+    void jumpToSourceLine(const Data::FileLine& line);
+
 signals:
     void jumpToCallerCallee(const Data::Symbol& symbol);
     void navigateToCode(const QString& file, int lineNumber, int columnNumber);

--- a/src/resultspage.cpp
+++ b/src/resultspage.cpp
@@ -165,6 +165,8 @@ ResultsPage::ResultsPage(PerfParser* parser, QWidget* parent)
 
     connect(m_resultsCallerCalleePage, &ResultsCallerCalleePage::jumpToDisassembly, this,
             &ResultsPage::onJumpToDisassembly);
+    connect(m_resultsCallerCalleePage, &ResultsCallerCalleePage::jumpToSourceCode, this,
+            &ResultsPage::onJumpToSourceCode);
     connect(m_resultsSummaryPage, &ResultsSummaryPage::jumpToCallerCallee, this, &ResultsPage::onJumpToCallerCallee);
     connect(m_resultsSummaryPage, &ResultsSummaryPage::openEditor, this, &ResultsPage::onOpenEditor);
     connect(m_resultsSummaryPage, &ResultsSummaryPage::selectSymbol, m_timeLineWidget, &TimeLineWidget::selectSymbol);
@@ -255,6 +257,13 @@ void ResultsPage::onJumpToDisassembly(const Data::Symbol& symbol)
     m_disassemblyDock->toggleAction()->setEnabled(true);
     m_resultsDisassemblyPage->setSymbol(symbol);
     showDock(m_disassemblyDock);
+}
+void ResultsPage::onJumpToSourceCode(const Data::Symbol& symbol, const Data::FileLine& line)
+{
+    onJumpToDisassembly(symbol);
+    if (line.isValid()) {
+        m_resultsDisassemblyPage->jumpToSourceLine(line);
+    }
 }
 
 void ResultsPage::setObjdump(const QString& objdump)

--- a/src/resultspage.h
+++ b/src/resultspage.h
@@ -23,6 +23,7 @@ class ResultsPage;
 
 namespace Data {
 struct Symbol;
+struct FileLine;
 }
 
 class PerfParser;
@@ -61,6 +62,7 @@ public slots:
     void onOpenEditor(const Data::Symbol& symbol);
     void showError(const QString& message);
     void onJumpToDisassembly(const Data::Symbol& symbol);
+    void onJumpToSourceCode(const Data::Symbol& symbol, const Data::FileLine& line);
 
 signals:
     void navigateToCode(const QString& url, int lineNumber, int columnNumber);


### PR DESCRIPTION
this patch adds a context menu that allows the user to select if he wants to open the source code or opens the disassembly and focus the selected location

closes: #515