### PR TITLE
[enhancement] cut 60% time for PerfParser::filterResults

### DIFF
--- a/src/models/data.h
+++ b/src/models/data.h
@@ -74,8 +74,8 @@ QDebug operator<<(QDebug stream, const Symbol& symbol);
 
 inline bool operator==(const Symbol& lhs, const Symbol& rhs)
 {
-    return std::tie(lhs.symbol, lhs.binary, lhs.path, lhs.relAddr)
-        == std::tie(rhs.symbol, rhs.binary, rhs.path, rhs.relAddr);
+    return std::tie(lhs.relAddr, lhs.symbol, lhs.binary, lhs.path)
+        == std::tie(rhs.relAddr, rhs.symbol, rhs.binary, rhs.path);
 }
 
 inline bool operator!=(const Symbol& lhs, const Symbol& rhs)


### PR DESCRIPTION
When change to "aggregate cost by symbol", filterResults spends a lot of time doing string comparison. This patch will reduce it dramatically.

The base version: origin/master, notice that operator== takes 50.6% time. total time **24.x** seconds
![image](https://github.com/KDAB/hotspot/assets/5919474/8afd5e99-46b3-4a1a-8edc-39b70b3164c5)

The optimized version: the cost of operator== has gone, the time is reduced to **10.x** seconds
![image](https://github.com/KDAB/hotspot/assets/5919474/bd390147-ee50-4241-85e6-2e41912a7a35)

