### PR TITLE
Add error message when exporting a flamegraph that hasn't been opened

### DIFF
--- a/src/flamegraph.cpp
+++ b/src/flamegraph.cpp
@@ -1149,6 +1149,8 @@ void FlameGraph::setData(FrameGraphicsItem* rootItem)
     if (isVisible()) {
         selectItem(m_rootItem);
     }
+
+    emit canConvertToImageChanged();
 }
 
 void FlameGraph::selectItem(int item)
@@ -1237,4 +1239,9 @@ void FlameGraph::updateNavigationActions()
     m_backAction->setEnabled(hasItems);
     m_forwardAction->setEnabled(isNotLastItem);
     m_resetAction->setEnabled(hasItems);
+}
+
+bool FlameGraph::canConvertToImage() const
+{
+    return m_rootItem != nullptr;
 }

--- a/src/flamegraph.h
+++ b/src/flamegraph.h
@@ -38,6 +38,7 @@ public:
 
     QImage toImage() const;
     void saveSvg(const QString& fileName) const;
+    bool canConvertToImage() const;
 
 protected:
     bool eventFilter(QObject* object, QEvent* event) override;
@@ -55,6 +56,7 @@ signals:
     void selectStack(const QVector<Data::Symbol>& stack, bool bottomUp);
     void jumpToDisassembly(const Data::Symbol& symbol);
     void uiResetRequested();
+    void canConvertToImageChanged();
 
 private:
     void setTooltipItem(const FrameGraphicsItem* item);

--- a/src/resultsflamegraphpage.cpp
+++ b/src/resultsflamegraphpage.cpp
@@ -44,6 +44,11 @@ ResultsFlameGraphPage::ResultsFlameGraphPage(FilterAndZoomStack* filterStack, Pe
     connect(parser, &PerfParser::bottomUpDataAvailable, this, [this, exportMenu](const Data::BottomUpResults& data) {
         ui->flameGraph->setBottomUpData(data);
         m_exportAction = exportMenu->addAction(QIcon::fromTheme(QStringLiteral("image-x-generic")), tr("Flamegraph"));
+        m_exportAction->setEnabled(ui->flameGraph->canConvertToImage());
+
+        connect(ui->flameGraph, &FlameGraph::canConvertToImageChanged, m_exportAction,
+                [this] { m_exportAction->setEnabled(ui->flameGraph->canConvertToImage()); });
+
         connect(m_exportAction, &QAction::triggered, this, [this]() {
             const auto filter = tr("Images (%1);;SVG (*.svg)").arg(imageFormatFilter());
             QString selectedFilter;


### PR DESCRIPTION
In order to save a flamegraph to an image or SVG, it must have been opened at least once so the graphics item is loaded. If you try to export it before doing so, you'll still get prompted to save the file, but it won't be (nor can be) written.

Now there's an explicit check with it's own error message in that case.