### PR TITLE
Enable position independent code for these tests

### DIFF
--- a/tests/test-clients/CMakeLists.txt
+++ b/tests/test-clients/CMakeLists.txt
@@ -3,6 +3,7 @@ include(CMakePushCheckState)
 # Check if static linking works at all. For example OpenSuse 42.3 with clang
 # doesn't ship a static libc++.a, making static linking fail.
 cmake_push_check_state(RESET)
+set(CMAKE_POSITION_INDEPENDENT_CODE On)
 set(CMAKE_REQUIRED_LIBRARIES "-static")
 set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 check_cxx_source_compiles("int main() {}" STATIC_LINKING_WORKS)


### PR DESCRIPTION
Fixes:
ld: error: relocation R_X86_64_32 cannot be used against local symbol; recompile with -fPIC
