### PR TITLE
Remove the date range from KDAB copyrights

### DIFF
--- a/LICENSE.GPL.txt
+++ b/LICENSE.GPL.txt
@@ -1,4 +1,4 @@
- The Hotspot software is Copyright (C) 2016-2020 Klaralvdalens Datakonsult AB.
+ The Hotspot software is © Klaralvdalens Datakonsult AB.
 
  You may use, distribute and copy the Hotspot software under the terms of
  the GNU General Public License version 2 or under the terms of GNU General

--- a/scripts/check_kallsyms.py
+++ b/scripts/check_kallsyms.py
@@ -1,7 +1,7 @@
 #!/bin/env python3
 #
 # SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-# SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+# SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/scripts/check_mmaps.py
+++ b/scripts/check_mmaps.py
@@ -1,7 +1,7 @@
 #!/bin/env python3
 #
 # SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-# SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+# SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/scripts/create_tarballs.sh
+++ b/scripts/create_tarballs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-# SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+# SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/src/aboutdialog.cpp
+++ b/src/aboutdialog.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Volker Krause <volker.krause@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/aboutdialog.h
+++ b/src/aboutdialog.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Volker Krause <volker.krause@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/costcontextmenu.cpp
+++ b/src/costcontextmenu.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/costcontextmenu.h
+++ b/src/costcontextmenu.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/costheaderview.cpp
+++ b/src/costheaderview.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/costheaderview.h
+++ b/src/costheaderview.h
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/dockwidgetsetup.cpp
+++ b/src/dockwidgetsetup.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/dockwidgetsetup.h
+++ b/src/dockwidgetsetup.h
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/flamegraph.cpp
+++ b/src/flamegraph.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/flamegraph.h
+++ b/src/flamegraph.h
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/frequencypage.cpp
+++ b/src/frequencypage.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/frequencypage.h
+++ b/src/frequencypage.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/callercalleemodel.cpp
+++ b/src/models/callercalleemodel.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/callercalleemodel.h
+++ b/src/models/callercalleemodel.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/callercalleeproxy.cpp
+++ b/src/models/callercalleeproxy.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/callercalleeproxy.h
+++ b/src/models/callercalleeproxy.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/costdelegate.cpp
+++ b/src/models/costdelegate.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/costdelegate.h
+++ b/src/models/costdelegate.h
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/costproxy.h
+++ b/src/models/costproxy.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/data.cpp
+++ b/src/models/data.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/data.h
+++ b/src/models/data.h
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/disassemblymodel.cpp
+++ b/src/models/disassemblymodel.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Darya Knysh <d.knysh@nips.ru>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/disassemblymodel.h
+++ b/src/models/disassemblymodel.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Darya Knysh <d.knysh@nips.ru>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/disassemblyoutput.cpp
+++ b/src/models/disassemblyoutput.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Darya Knysh <d.knysh@nips.ru>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/disassemblyoutput.h
+++ b/src/models/disassemblyoutput.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Darya Knysh <d.knysh@nips.ru>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/eventmodel.cpp
+++ b/src/models/eventmodel.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/eventmodel.h
+++ b/src/models/eventmodel.h
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/filterandzoomstack.cpp
+++ b/src/models/filterandzoomstack.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/filterandzoomstack.h
+++ b/src/models/filterandzoomstack.h
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/frequencymodel.cpp
+++ b/src/models/frequencymodel.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/frequencymodel.h
+++ b/src/models/frequencymodel.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/hashmodel.h
+++ b/src/models/hashmodel.h
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/processfiltermodel.cpp
+++ b/src/models/processfiltermodel.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/processfiltermodel.h
+++ b/src/models/processfiltermodel.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/processmodel.cpp
+++ b/src/models/processmodel.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/processmodel.h
+++ b/src/models/processmodel.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/timeaxisheaderview.cpp
+++ b/src/models/timeaxisheaderview.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Koen Poppe
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/timeaxisheaderview.h
+++ b/src/models/timeaxisheaderview.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Koen Poppe
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/timelinedelegate.cpp
+++ b/src/models/timelinedelegate.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/timelinedelegate.h
+++ b/src/models/timelinedelegate.h
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/topproxy.cpp
+++ b/src/models/topproxy.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/topproxy.h
+++ b/src/models/topproxy.h
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/treemodel.cpp
+++ b/src/models/treemodel.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/models/treemodel.h
+++ b/src/models/treemodel.h
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/multiconfigwidget.cpp
+++ b/src/multiconfigwidget.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/multiconfigwidget.h
+++ b/src/multiconfigwidget.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/parsers/perf/perfparser.cpp
+++ b/src/parsers/perf/perfparser.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/parsers/perf/perfparser.h
+++ b/src/parsers/perf/perfparser.h
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/perfoutputwidget.cpp
+++ b/src/perfoutputwidget.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/perfoutputwidget.h
+++ b/src/perfoutputwidget.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/perfoutputwidgetkonsole.cpp
+++ b/src/perfoutputwidgetkonsole.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/perfoutputwidgetkonsole.h
+++ b/src/perfoutputwidgetkonsole.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/perfoutputwidgettext.cpp
+++ b/src/perfoutputwidgettext.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/perfoutputwidgettext.h
+++ b/src/perfoutputwidgettext.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Lieven Hey <lieven.hey@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/perfrecord.cpp
+++ b/src/perfrecord.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/perfrecord.h
+++ b/src/perfrecord.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/recordpage.cpp
+++ b/src/recordpage.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/recordpage.h
+++ b/src/recordpage.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/resultsbottomuppage.cpp
+++ b/src/resultsbottomuppage.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/resultsbottomuppage.h
+++ b/src/resultsbottomuppage.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/resultscallercalleepage.cpp
+++ b/src/resultscallercalleepage.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/resultscallercalleepage.h
+++ b/src/resultscallercalleepage.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/resultsdisassemblypage.cpp
+++ b/src/resultsdisassemblypage.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Darya Knysh <d.knysh@nips.ru>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/resultsdisassemblypage.h
+++ b/src/resultsdisassemblypage.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Darya Knysh <d.knysh@nips.ru>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/resultsflamegraphpage.cpp
+++ b/src/resultsflamegraphpage.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/resultsflamegraphpage.h
+++ b/src/resultsflamegraphpage.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/resultspage.cpp
+++ b/src/resultspage.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/resultspage.h
+++ b/src/resultspage.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/resultssummarypage.cpp
+++ b/src/resultssummarypage.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/resultssummarypage.h
+++ b/src/resultssummarypage.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/resultstopdownpage.cpp
+++ b/src/resultstopdownpage.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/resultstopdownpage.h
+++ b/src/resultstopdownpage.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/resultsutil.cpp
+++ b/src/resultsutil.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/resultsutil.h
+++ b/src/resultsutil.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Erik Johansson <erik@ejohansson.se>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/settings.h
+++ b/src/settings.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Erik Johansson <erik@ejohansson.se>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Petr Lyapidevskiy <p.lyapidevskiy@nips.ru>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Petr Lyapidevskiy <p.lyapidevskiy@nips.ru>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/startpage.cpp
+++ b/src/startpage.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/startpage.h
+++ b/src/startpage.h
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/timelinewidget.cpp
+++ b/src/timelinewidget.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/timelinewidget.h
+++ b/src/timelinewidget.h
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/util.h
+++ b/src/util.h
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/tests/integrationtests/dump_perf_data.cpp
+++ b/tests/integrationtests/dump_perf_data.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/tests/integrationtests/elfwalk.cpp
+++ b/tests/integrationtests/elfwalk.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/tests/integrationtests/tst_perfparser.cpp
+++ b/tests/integrationtests/tst_perfparser.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Nate Rogers <nate.rogers@kdab.com>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/tests/modeltests/tst_disassemblyoutput.cpp
+++ b/tests/modeltests/tst_disassemblyoutput.cpp
@@ -1,7 +1,7 @@
 /*
     SPDX-FileCopyrightText: Darya Knysh <d.knysh@nips.ru>
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/tests/modeltests/tst_models.cpp
+++ b/tests/modeltests/tst_models.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/tests/modeltests/tst_timelinedelegate.cpp
+++ b/tests/modeltests/tst_timelinedelegate.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/tests/test-clients/c-fork/c-fork.c
+++ b/tests/test-clients/c-fork/c-fork.c
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/tests/test-clients/c-syscalls/main.c
+++ b/tests/test-clients/c-syscalls/main.c
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/tests/test-clients/cpp-inlining/main.cpp
+++ b/tests/test-clients/cpp-inlining/main.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/tests/test-clients/cpp-locking/main.cpp
+++ b/tests/test-clients/cpp-locking/main.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/tests/test-clients/cpp-minimal-static/main.cpp
+++ b/tests/test-clients/cpp-minimal-static/main.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/tests/test-clients/cpp-parallel/main.cpp
+++ b/tests/test-clients/cpp-parallel/main.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/tests/test-clients/cpp-recursion/main.cpp
+++ b/tests/test-clients/cpp-recursion/main.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/tests/test-clients/cpp-sleep/main.cpp
+++ b/tests/test-clients/cpp-sleep/main.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/tests/test-clients/cpp-stdin/main.cpp
+++ b/tests/test-clients/cpp-stdin/main.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/tests/test-clients/cpp-threadnames/main.cpp
+++ b/tests/test-clients/cpp-threadnames/main.cpp
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/tests/testutils.h
+++ b/tests/testutils.h
@@ -1,6 +1,6 @@
 /*
     SPDX-FileCopyrightText: Milian Wolff <milian.wolff@kdab.com>
-    SPDX-FileCopyrightText: 2016-2022 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 
     SPDX-License-Identifier: GPL-2.0-or-later
 */


### PR DESCRIPTION
Keep the file creationYear as part of the copyright but no longer worry about extending the date range to include the currentYear.

This standardizes to KDAB copyright policy.