### PR TITLE
add ci test for non optional build

### DIFF
--- a/.github/workflows/compile-and-test.yml
+++ b/.github/workflows/compile-and-test.yml
@@ -137,6 +137,29 @@ jobs:
         name: clang-tidy-fixits
         path: scripts/fixits/fixits.yaml
 
+  archlinux-without-optional:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+
+    runs-on: ubuntu-latest
+    container: ghcr.io/kdab/hotspot-archlinuxwithoutoptional-dependencies
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Configure
+      run: cmake --preset dev-asan
+           -DCMAKE_CXX_FLAGS_INIT=-Werror -DCMAKE_C_FLAGS_INIT=-Werror
+
+    - name: Build
+      run: cmake --build --preset dev-asan
+
+    - name: Test
+      run: ctest --preset dev-asan
+
   fedora34:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}

--- a/scripts/compile-test/BaseArchlinuxWithoutOptional
+++ b/scripts/compile-test/BaseArchlinuxWithoutOptional
@@ -1,0 +1,10 @@
+FROM archlinux:latest
+
+# install dependencies
+
+RUN pacman -Sy --noconfirm && \
+    pacman -S archlinux-keyring --noconfirm && pacman-key --init && pacman-key --populate && \
+    pacman -Syu --noconfirm git make qt5-x11extras cmake gcc extra-cmake-modules \
+    libelf gettext qt5-base ninja \
+    threadweaver5 kconfigwidgets5 knotifications5 \
+    kiconthemes5 kitemviews5 kitemmodels5 kwindowsystem5 kio5 kparts5 solid5 clazy python python-yaml

--- a/scripts/compile-test/build.sh
+++ b/scripts/compile-test/build.sh
@@ -72,6 +72,7 @@ export DOCKER_BUILDKIT=1
 buildHotspotWithoutPresets Ubuntu20.04 1.6
 buildHotspotWithPresets Ubuntu22.04 2.0
 buildHotspotWithPresets Archlinux 2.0
+buildHotspotWithPresets ArchlinuxWithoutOptional 2.0
 buildHotspotWithPresets OpenSuseTumbleweed 2.0
 buildHotspotWithoutPresets Fedora34 2.0
 buildHotspotWithPresets NeonQt6 2.0

--- a/scripts/compile-test/push.sh
+++ b/scripts/compile-test/push.sh
@@ -21,6 +21,7 @@ pushDependencies()
 pushDependencies ubuntu20.04
 pushDependencies ubuntu22.04
 pushDependencies archlinux
+pushDependencies archlinuxwithoutoptional
 pushDependencies opensusetumbleweed
 pushDependencies fedora34
 pushDependencies neonqt6

--- a/src/models/highlightedtext.cpp
+++ b/src/models/highlightedtext.cpp
@@ -94,9 +94,9 @@ public:
     HighlightingImplementation(KSyntaxHighlighting::Repository* /*repository*/) { }
     virtual ~HighlightingImplementation() = default;
 
-    virtual QVector<QTextLayout::FormatRange> format(const QString& /*text*/)
+    virtual QVector<QTextLayout::FormatRange> format(const QString& text)
     {
-        return {};
+        return {{QTextLayout::FormatRange {0, text.length(), {}}}};
     }
 
     virtual void themeChanged() { }


### PR DESCRIPTION
This commit adds a ci build to build hotspot without optional dependencies. This should prevents bugs like #575 (fails to build without qcustomplot).