### PR TITLE
fix wrong source code shown

### DIFF
--- a/src/models/highlightedtext.cpp
+++ b/src/models/highlightedtext.cpp
@@ -186,6 +186,7 @@ private:
 class HighlightedLine
 {
 public:
+    HighlightedLine() = default;
     HighlightedLine(HighlightingImplementation* highlighter, QString text)
         : m_highlighter(highlighter)
         , m_text(std::move(text))
@@ -227,7 +228,7 @@ private:
         return layout;
     }
 
-    HighlightingImplementation* m_highlighter;
+    HighlightingImplementation* m_highlighter = nullptr;
     QString m_text;
     mutable std::unique_ptr<QTextLayout> m_layout;
 };
@@ -258,13 +259,13 @@ void HighlightedText::setText(const QStringList& text)
         emit usesAnsiChanged(usesAnsi);
     }
 
-    m_highlightedLines.reserve(text.size());
-    std::transform(text.cbegin(), text.cend(), std::back_inserter(m_highlightedLines), [this](const QString& text) {
+    m_highlightedLines.resize(text.size());
+    std::transform(text.cbegin(), text.cend(), m_highlightedLines.begin(), [this](const QString& text) {
         return HighlightedLine {m_highlighter.get(), text};
     });
 
-    m_cleanedLines.reserve(text.size());
-    std::transform(text.cbegin(), text.cend(), std::back_inserter(m_cleanedLines), Util::removeAnsi);
+    m_cleanedLines = text;
+    std::for_each(m_cleanedLines.begin(), m_cleanedLines.end(), Util::removeAnsi);
 }
 
 void HighlightedText::setDefinition(const KSyntaxHighlighting::Definition& definition)

--- a/src/models/highlightedtext.cpp
+++ b/src/models/highlightedtext.cpp
@@ -263,8 +263,6 @@ void HighlightedText::setText(const QStringList& text)
         return HighlightedLine {m_highlighter.get(), text};
     });
 
-    connect(this, &HighlightedText::definitionChanged, this, &HighlightedText::updateHighlighting);
-
     m_cleanedLines.reserve(text.size());
     std::transform(text.cbegin(), text.cend(), std::back_inserter(m_cleanedLines), Util::removeAnsi);
 }
@@ -275,6 +273,7 @@ void HighlightedText::setDefinition(const KSyntaxHighlighting::Definition& defin
     m_highlighter->setHighlightingDefinition(definition);
 #if KFSyntaxHighlighting_FOUND
     emit definitionChanged(definition.name());
+    updateHighlighting();
 #endif
 }
 

--- a/src/models/highlightedtext.h
+++ b/src/models/highlightedtext.h
@@ -57,7 +57,7 @@ public slots:
 private:
     KSyntaxHighlighting::Repository* m_repository;
     std::unique_ptr<HighlightingImplementation> m_highlighter;
-    mutable std::vector<HighlightedLine> m_highlightedLines;
+    std::vector<HighlightedLine> m_highlightedLines;
     QStringList m_lines;
     QStringList m_cleanedLines;
     bool m_isUsingAnsi = false;


### PR DESCRIPTION
The vectors containing the source code are not reset correctly. This results one some old code being shown. This patch resets them correctly.

fixes: #577