### PR TITLE
HighlightedText: Check m_highlighter for nullptr

### DIFF
--- a/src/models/highlightedtext.cpp
+++ b/src/models/highlightedtext.cpp
@@ -304,7 +304,8 @@ QTextLayout* HighlightedText::layoutForLine(int index)
 
 void HighlightedText::updateHighlighting()
 {
-    m_highlighter->themeChanged();
+    if (m_highlighter)
+        m_highlighter->themeChanged();
     std::for_each(m_highlightedLines.begin(), m_highlightedLines.end(),
                   [](HighlightedLine& line) { line.updateHighlighting(); });
 }


### PR DESCRIPTION
Otherwise Hotspot crashes when changing the color scheme before a trace has been loaded.

---

Wanted to debug why Plasma’s color settings module was slow when changing the color and instead had Hotspot crash whenever I did.