### PR TITLE
fix: warnings in ci runs

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -22,7 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/kdab/kdesrc-build
-      options: --privileged --device /dev/fuse --cap-add SYS_ADMIN
 
     steps:
     - name: Checkout

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -20,27 +20,25 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
 
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/kdab/kdesrc-build
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: recursive
 
     - name: Build
-      run: scripts/appimage/build_appimage.sh "$PWD" "$PWD/build"
+      uses: docker://ghcr.io/kdab/kdesrc-build:latest
 
     - name: Upload AppImage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: appimage
-        path: /output/hotspot*.AppImage
+        path: ${{ github.workspace }}/*.AppImage
 
     - name: Upload Debug Info
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: debuginfo
-        path: /output/hotspot-debuginfo-*
+        path: ${{ github.workspace }}/hotspot-debuginfo-*

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.11.x
-    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit/action@v3.0.1

--- a/scripts/appimage/Dockerfile
+++ b/scripts/appimage/Dockerfile
@@ -65,9 +65,10 @@ RUN wget https://download.qt.io/official_releases/qt/5.15/${QT_VERSION}/single/q
     -release -ssl -no-compile-examples -cups -I /usr/include/openssl11 -prefix /usr && \
     make -j$(nproc) && make install && cd .. && rm -Rf build qt-everywhere-*
 
-# appimage build tools
-RUN wget https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20230713-1/linuxdeploy-x86_64.AppImage &&     chmod +x linuxdeploy-x86_64.AppImage && \
-    wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage && chmod +x linuxdeploy-plugin-qt-x86_64.AppImage && mv linuxdeploy* /usr/bin/
+RUN cd /opt && wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage && chmod +x linuxdeploy-x86_64.AppImage && ./linuxdeploy-x86_64.AppImage --appimage-extract && \
+    wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage && chmod +x linuxdeploy-plugin-qt-x86_64.AppImage && ./linuxdeploy-plugin-qt-x86_64.AppImage --appimage-extract && \
+    wget https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage && chmod +x linuxdeploy-plugin-appimage-x86_64.AppImage && ./linuxdeploy-plugin-appimage-x86_64.AppImage --appimage-extract && \
+    cd squashfs-root && rsync -a usr/ /usr && rsync -a plugins/linuxdeploy-plugin-appimage/ / && cd /opt && rm -rf squashfs-root && rm -rf *.AppImage
 
 # qcustomplot
 RUN cd /opt && mkdir qcustomplot && cd qcustomplot && \

--- a/scripts/appimage/Dockerfile
+++ b/scripts/appimage/Dockerfile
@@ -128,4 +128,5 @@ RUN cd /opt && git clone --recursive https://github.com/KDAB/KDDockWidgets.git -
 FROM intermediate
 
 WORKDIR /
-RUN mkdir /output
+# set the entrypoint to the build script so that the build script will be run by github actions
+CMD ["/github/workspace/scripts/appimage/build_appimage.sh", "/github/workspace", "/github/workspace/build"]

--- a/scripts/appimage/build_appimage.sh
+++ b/scripts/appimage/build_appimage.sh
@@ -30,7 +30,7 @@ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 make -j$(nproc)
 DESTDIR=appdir make install
 
-tar -cjvf "/output/hotspot-debuginfo-$gitversion-x86_64.tar.bz2" \
+tar -cjvf "/github/workspace/hotspot-debuginfo-$gitversion-x86_64.tar.bz2" \
     --transform="s#appdir/#hotspot-debuginfo-$gitversion/#" \
     appdir/usr/bin/hotspot appdir/usr/lib64/libexec/hotspot-perfparser
 
@@ -74,4 +74,4 @@ linuxdeploy --appdir appdir --plugin qt \
     -d "./appdir/usr/share/applications/com.kdab.hotspot.desktop" \
     --output appimage
 
-mv Hotspot*x86_64.AppImage "/output/hotspot-$gitversion-x86_64.AppImage"
+mv Hotspot*x86_64.AppImage "/github/workspace/hotspot-$gitversion-x86_64.AppImage"

--- a/scripts/appimage/build_appimage.sh
+++ b/scripts/appimage/build_appimage.sh
@@ -61,7 +61,7 @@ cp -v "/usr/share/icons/breeze/breeze-icons.rcc" "appdir/usr/share/icons/breeze/
 # TODO: further down also add:
 # -e "./appdir/usr/plugins/kgraphviewerpart.so" \
 
-linuxdeploy-x86_64.AppImage --appdir appdir --plugin qt \
+linuxdeploy --appdir appdir --plugin qt \
     -e "./appdir/usr/lib64/libexec/hotspot-perfparser" \
     -e "./appdir/usr/bin/hotspot" \
     -l "/usr/lib64/libz.so.1" \

--- a/scripts/appimage/build_appimage_in_docker.sh
+++ b/scripts/appimage/build_appimage_in_docker.sh
@@ -13,7 +13,6 @@ cd "$(dirname $0)"
 mkdir -p ../output/build-appimage
 
 docker run -it \
-    -v $PWD/../output:/output \
-    -v $PWD/../../:/hotspot \
+    -v $PWD/../../:/github/workspace/ \
     ghcr.io/kdab/kdesrc-build:latest \
-    /hotspot/scripts/appimage/build_appimage.sh /hotspot /output/build-appimage
+    /github/workspace/scripts/appimage/build_appimage.sh /github/workspace /github/workspace/build/build-appimage

--- a/scripts/appimage/build_appimage_in_docker.sh
+++ b/scripts/appimage/build_appimage_in_docker.sh
@@ -12,7 +12,7 @@ cd "$(dirname $0)"
 
 mkdir -p ../output/build-appimage
 
-docker run -it --privileged --device /dev/fuse --cap-add SYS_ADMIN \
+docker run -it \
     -v $PWD/../output:/output \
     -v $PWD/../../:/hotspot \
     ghcr.io/kdab/kdesrc-build:latest \


### PR DESCRIPTION
This patch fixes the deprecation warnings in the pre-commit run since github retires the old node16 runner.