### PR TITLE
build: disable building tests when building appimage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,9 @@ add_subdirectory(3rdparty)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_subdirectory(src)
 
-add_subdirectory(tests)
+if(NOT APPIMAGE_BUILD)
+    add_subdirectory(tests)
+endif()
 
 install(
     FILES com.kdab.hotspot.desktop


### PR DESCRIPTION
When building the appimage we don't use the test binaries so we can skip building them to reduce build time.