### PR TITLE
Clear the error when changing the record type

### DIFF
--- a/src/recordhost.cpp
+++ b/src/recordhost.cpp
@@ -333,6 +333,7 @@ void RecordHost::setRecordType(RecordType type)
 {
     if (m_recordType != type) {
         m_recordType = type;
+        emit errorOccurred({});
         emit recordTypeChanged(m_recordType);
 
         m_pids.clear();


### PR DESCRIPTION
When changing the record type, previous errors may no longer be applicable (for example the application having been unset in the "launch application" mode is not relevant at all to the "attach to process" mode). Clear them to allow starting the recording in the new mode again (as long as that doesn't create legitimate errors again).