### PR TITLE
fix: crash if samples have different amount of costs associated

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     args: [--allow-multiple-documents]
   - id: check-json
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v14.0.0
+  rev: v17.0.6
   hooks:
   - id: clang-format
     files: (\.cpp|\.h|\.c)

--- a/src/models/data.h
+++ b/src/models/data.h
@@ -203,7 +203,87 @@ struct FrameLocation
     Data::Location location;
 };
 
-using ItemCost = std::valarray<qint64>;
+class ItemCost
+{
+public:
+    ItemCost(std::size_t size = 0)
+        : m_cost(size)
+    {
+    }
+
+    ItemCost(qint64 value, std::size_t count)
+        : m_cost(value, count)
+    {
+    }
+
+    ItemCost(std::valarray<qint64> cost)
+        : m_cost(std::move(cost))
+    {
+    }
+
+    void resize(std::size_t newSize, qint64 value = 0)
+    {
+        m_cost.resize(newSize, value);
+    }
+    std::size_t size() const
+    {
+        return m_cost.size();
+    }
+
+    ItemCost operator+(const ItemCost& rhs) const
+    {
+        return {m_cost + rhs.m_cost};
+    }
+
+    ItemCost operator-(const ItemCost& rhs) const
+    {
+        return {m_cost - rhs.m_cost};
+    }
+
+    ItemCost& operator+=(const ItemCost& rhs)
+    {
+        m_cost += rhs.m_cost;
+        return *this;
+    }
+
+    ItemCost& operator-=(const ItemCost& rhs)
+    {
+        m_cost -= rhs.m_cost;
+        return *this;
+    }
+
+    qint64& operator[](int index)
+    {
+        if (static_cast<std::size_t>(index) >= m_cost.size()) {
+            resize(index + 1);
+        }
+        return m_cost[index];
+    }
+    qint64 operator[](int index) const
+    {
+        if (static_cast<std::size_t>(index) < m_cost.size()) {
+            return m_cost[index];
+        }
+        return 0;
+    }
+
+    qint64 sum() const
+    {
+        return m_cost.sum();
+    }
+
+    auto begin() const
+    {
+        return std::begin(m_cost);
+    }
+    auto end() const
+    {
+        return std::end(m_cost);
+    }
+
+private:
+    std::valarray<qint64> m_cost;
+};
 
 QDebug operator<<(QDebug stream, const ItemCost& cost);
 

--- a/src/recordpage.cpp
+++ b/src/recordpage.cpp
@@ -40,6 +40,8 @@
 #include <Solid/Device>
 #include <Solid/Processor>
 
+#include <cmath>
+
 #include "multiconfigwidget.h"
 #include "perfoutputwidgetkonsole.h"
 #include "perfoutputwidgettext.h"

--- a/src/util.h
+++ b/src/util.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <valarray>
 #include <QHashFunctions>
 #include <QtGlobal>
 
@@ -20,7 +19,7 @@ struct Symbol;
 struct FileLine;
 struct LocationCost;
 class Costs;
-using ItemCost = std::valarray<qint64>;
+class ItemCost;
 }
 
 namespace KParts {


### PR DESCRIPTION
If we have a recording with the following layout: A B C where A: part where function f is accessed
B: list samples
C: part where function g is accessed
then f won't have the lost events cost while g does. This will cause a crash when the model tries to access it

fixes: #629