### PR TITLE
ci: disable trim whitespace for markdown files

### DIFF
--- a/.mdlrc.rb
+++ b/.mdlrc.rb
@@ -1,4 +1,5 @@
 all
+rule 'MD009', :br_spaces => 2
 rule 'MD013', :line_length => 120, :tables => false, :code_blocks => false
 rule 'MD029', :style => :ordered
 exclude_rule 'MD033'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
   hooks:
   - id: trailing-whitespace
     exclude: (tests/modeltests/disassembly/)
+    args: ["--markdown-linebreak-ext=md,markdown"]
   - id: end-of-file-fixer
   - id: check-added-large-files
     args: ['--maxkb=1000']


### PR DESCRIPTION
A double whitespace at the end of a line is valid markdown so we should not remove those.