### PR TITLE
fix: also support ' and , as branch visualization characters

### DIFF
--- a/src/resultsdisassemblypage.cpp
+++ b/src/resultsdisassemblypage.cpp
@@ -142,9 +142,11 @@ public:
                 startHorizontalLine(x);
                 verticalLine();
                 break;
+            case '\'':
             case '\\':
                 topRightEdge();
                 break;
+            case ',':
             case '/':
                 bottomLeftEdge();
                 break;

--- a/tests/modeltests/tst_disassemblyoutput.cpp
+++ b/tests/modeltests/tst_disassemblyoutput.cpp
@@ -243,9 +243,10 @@ private slots:
         QVERIFY(result.errorMessage.isEmpty());
 
         auto isValidVisualisationCharacter = [](QChar character) {
-            const static auto validCharacters = std::initializer_list<QChar> {
-                QLatin1Char(' '), QLatin1Char('\t'), QLatin1Char('|'), QLatin1Char('/'), QLatin1Char('\\'),
-                QLatin1Char('-'), QLatin1Char('>'),  QLatin1Char('+'), QLatin1Char('X')};
+            const static auto validCharacters =
+                std::initializer_list<QChar> {QLatin1Char(' '),  QLatin1Char('\t'), QLatin1Char('|'), QLatin1Char('/'),
+                                              QLatin1Char('\\'), QLatin1Char('-'),  QLatin1Char('>'), QLatin1Char('+'),
+                                              QLatin1Char('X'),  QLatin1Char(','),  QLatin1Char('\'')};
 
             return std::any_of(validCharacters.begin(), validCharacters.end(),
                                [character](auto validCharacter) { return character == validCharacter; });


### PR DESCRIPTION
My objdump from arch uses these chars now, so let's support them too