### PR TITLE
feat: support regex search

### DIFF
--- a/src/flamegraph.h
+++ b/src/flamegraph.h
@@ -45,7 +45,7 @@ protected:
 
 private slots:
     void setData(FrameGraphicsItem* rootItem);
-    void setSearchValue(const QString& value);
+    void setSearchValue(const QString& value, bool useRegex);
     void navigateBack();
     void navigateForward();
 
@@ -88,6 +88,7 @@ private:
     bool m_collapseRecursion = false;
     bool m_buildingScene = false;
     QString m_search;
+    bool m_useRegex = false;
     // cost threshold in percent, items below that value will not be shown
     static const constexpr double DEFAULT_COST_THRESHOLD = 0.1;
     double m_costThreshold = DEFAULT_COST_THRESHOLD;

--- a/src/recordpage.cpp
+++ b/src/recordpage.cpp
@@ -415,7 +415,7 @@ RecordPage::RecordPage(QWidget* parent)
                 m_recordHost->setPids(pids);
             });
 
-    ResultsUtil::connectFilter(ui->processesFilterBox, m_processProxyModel);
+    ResultsUtil::connectFilter(ui->processesFilterBox, m_processProxyModel, ui->regexCheckBox);
 
     connect(m_watcher, &QFutureWatcher<ProcDataList>::finished, this, &RecordPage::updateProcessesFinished);
 

--- a/src/recordpage.ui
+++ b/src/recordpage.ui
@@ -144,16 +144,6 @@
         <property name="text">
          <string>Process Filter:</string>
         </property>
-        <property name="buddy">
-         <cstring>processesFilterBox</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="processesFilterBox">
-        <property name="toolTip">
-         <string>Filter the process list by process name or process ID</string>
-        </property>
        </widget>
       </item>
       <item row="1" column="0">
@@ -183,6 +173,38 @@
         <property name="uniformRowHeights">
          <bool>true</bool>
         </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QWidget" name="widget_2" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLineEdit" name="processesFilterBox">
+           <property name="toolTip">
+            <string>Filter the process list by process name or process ID</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="regexCheckBox">
+           <property name="text">
+            <string>Regex Search</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>

--- a/src/resultsbottomuppage.cpp
+++ b/src/resultsbottomuppage.cpp
@@ -61,7 +61,8 @@ ResultsBottomUpPage::ResultsBottomUpPage(FilterAndZoomStack* filterStack, PerfPa
     ui->setupUi(this);
 
     auto bottomUpCostModel = new BottomUpModel(this);
-    ResultsUtil::setupTreeView(ui->bottomUpTreeView, contextMenu, ui->bottomUpSearch, bottomUpCostModel);
+    ResultsUtil::setupTreeView(ui->bottomUpTreeView, contextMenu, ui->bottomUpSearch, ui->regexCheckBox,
+                               bottomUpCostModel);
     ResultsUtil::setupCostDelegate(bottomUpCostModel, ui->bottomUpTreeView);
     ResultsUtil::setupContextMenu(ui->bottomUpTreeView, contextMenu, bottomUpCostModel, filterStack, this);
 

--- a/src/resultsbottomuppage.ui
+++ b/src/resultsbottomuppage.ui
@@ -71,6 +71,13 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="regexCheckBox">
+        <property name="text">
+         <string>Regex Search</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/resultscallercalleepage.cpp
+++ b/src/resultscallercalleepage.cpp
@@ -84,7 +84,7 @@ ResultsCallerCalleePage::ResultsCallerCalleePage(FilterAndZoomStack* filterStack
     m_callerCalleeProxy = new CallerCalleeProxy<CallerCalleeModel>(this);
     m_callerCalleeProxy->setSourceModel(m_callerCalleeCostModel);
     m_callerCalleeProxy->setSortRole(CallerCalleeModel::SortRole);
-    ResultsUtil::connectFilter(ui->callerCalleeFilter, m_callerCalleeProxy);
+    ResultsUtil::connectFilter(ui->callerCalleeFilter, m_callerCalleeProxy, ui->regexCheckBox);
     ui->callerCalleeTableView->setSortingEnabled(true);
     ui->callerCalleeTableView->setModel(m_callerCalleeProxy);
     ResultsUtil::setupContextMenu(ui->callerCalleeTableView, contextMenu, m_callerCalleeCostModel, filterStack, this,

--- a/src/resultscallercalleepage.ui
+++ b/src/resultscallercalleepage.ui
@@ -71,6 +71,13 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="regexCheckBox">
+        <property name="text">
+         <string>Regex Search</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/resultstopdownpage.cpp
+++ b/src/resultstopdownpage.cpp
@@ -22,7 +22,8 @@ ResultsTopDownPage::ResultsTopDownPage(FilterAndZoomStack* filterStack, PerfPars
     ui->setupUi(this);
 
     auto topDownCostModel = new TopDownModel(this);
-    ResultsUtil::setupTreeView(ui->topDownTreeView, contextMenu, ui->topDownSearch, topDownCostModel);
+    ResultsUtil::setupTreeView(ui->topDownTreeView, contextMenu, ui->topDownSearch, ui->regexCheckBox,
+                               topDownCostModel);
     ResultsUtil::setupCostDelegate(topDownCostModel, ui->topDownTreeView);
     ResultsUtil::setupContextMenu(ui->topDownTreeView, contextMenu, topDownCostModel, filterStack, this);
 

--- a/src/resultstopdownpage.ui
+++ b/src/resultstopdownpage.ui
@@ -71,6 +71,13 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="regexCheckBox">
+        <property name="text">
+         <string>Regex Search</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/resultsutil.h
+++ b/src/resultsutil.h
@@ -19,6 +19,7 @@ class QComboBox;
 class QLineEdit;
 class QSortFilterProxyModel;
 class QAbstractItemModel;
+class QCheckBox;
 
 namespace Data {
 class Costs;
@@ -31,18 +32,19 @@ class CostContextMenu;
 namespace ResultsUtil {
 void setupHeaderView(QTreeView* view, CostContextMenu* contextMenu);
 
-void connectFilter(QLineEdit* filter, QSortFilterProxyModel* proxy);
+void connectFilter(QLineEdit* filter, QSortFilterProxyModel* proxy, QCheckBox* regexCheckBox);
 
-void setupTreeView(QTreeView* view, CostContextMenu* contextMenu, QLineEdit* filter, QSortFilterProxyModel* model,
-                   int initialSortColumn, int sortRole);
+void setupTreeView(QTreeView* view, CostContextMenu* contextMenu, QLineEdit* filter, QCheckBox* regexSearchCheckBox,
+                   QSortFilterProxyModel* model, int initialSortColumn, int sortRole);
 
 template<typename Model>
-void setupTreeView(QTreeView* view, CostContextMenu* costContextMenu, QLineEdit* filter, Model* model)
+void setupTreeView(QTreeView* view, CostContextMenu* costContextMenu, QLineEdit* filter, QCheckBox* regexSearchCheckBox,
+                   Model* model)
 {
     auto* proxy = new CostProxy<Model>(view);
     proxy->setSourceModel(model);
-    setupTreeView(view, costContextMenu, filter, qobject_cast<QSortFilterProxyModel*>(proxy), Model::InitialSortColumn,
-                  Model::SortRole);
+    setupTreeView(view, costContextMenu, filter, regexSearchCheckBox, qobject_cast<QSortFilterProxyModel*>(proxy),
+                  Model::InitialSortColumn, Model::SortRole);
 }
 
 void setupCostDelegate(QAbstractItemModel* model, QTreeView* view, int sortRole, int totalCostRole, int numBaseColumns);

--- a/src/timelinewidget.cpp
+++ b/src/timelinewidget.cpp
@@ -67,7 +67,7 @@ TimeLineWidget::TimeLineWidget(PerfParser* parser, QMenu* filterMenu, FilterAndZ
     timeLineProxy->setSortRole(EventModel::SortRole);
     timeLineProxy->setFilterKeyColumn(EventModel::ThreadColumn);
     timeLineProxy->setFilterRole(Qt::DisplayRole);
-    ResultsUtil::connectFilter(ui->timeLineSearch, timeLineProxy);
+    ResultsUtil::connectFilter(ui->timeLineSearch, timeLineProxy, ui->regexCheckBox);
     ui->timeLineView->setModel(timeLineProxy);
     ui->timeLineView->setSortingEnabled(true);
     // ensure the vertical scroll bar is always shown, otherwise the timeline

--- a/src/timelinewidget.ui
+++ b/src/timelinewidget.ui
@@ -65,6 +65,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="regexCheckBox">
+       <property name="text">
+        <string>Regex Search</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Event Source:</string>


### PR DESCRIPTION
Since we use QSortFilterProxyModel we get this for free. This patch adds support for regex search by not escaping the search term if it is prefix with %.
For the flamegraph there is a custom implementation, which changes the current QString::contains to a QRegularExpression::match call.

Closes: #666