### PR TITLE
Fix crash because "Stop Recording" could be pressed twice

### DIFF
--- a/src/recordpage.cpp
+++ b/src/recordpage.cpp
@@ -649,6 +649,9 @@ void RecordPage::onStartRecordingButtonClicked(bool checked)
             break;
         }
     } else {
+        m_updateRuntimeTimer->stop();
+        ui->startRecordingButton->setText(tr("Stopping recording..."));
+        ui->startRecordingButton->setEnabled(false);
         stopRecording();
     }
 }


### PR DESCRIPTION
Disable the stop button as soon as it is pressed instead of waiting to do it in the `recordingStopped` function, so it can't be pressed again which caused a crash. The `recordingStopped` function isn't immediately called after pressing stop because perf can take a while to finish after it is asked to terminate (eg: if debuginfod is enabled and has to download symbols, or if the trace is very big).