### PR TITLE
Fix build with Qt 6.9

### DIFF
--- a/src/models/timelinedelegate.cpp
+++ b/src/models/timelinedelegate.cpp
@@ -194,7 +194,7 @@ void TimeLineDelegate::paint(QPainter* painter, const QStyleOptionViewItem& opti
         painter->drawRect(threadTimeRect.adjusted(-1, -1, 0, 0));
 
         // visualize all events
-        painter->setBrush({});
+        painter->setBrush(QBrush());
 
         if (offCpuCostId != -1) {
             const auto offCpuColor = scheme.background(KColorScheme::NegativeBackground).color();


### PR DESCRIPTION
That version added some overloads to setBrush [1], making the {} ambiguous:
"hotspot/src/models/timelinedelegate.cpp:197:26: error: call of overloaded 'setBrush(<brace-enclosed initializer list>)' is ambiguous"

[1] qtbase commit: 2ad79c626d7a94e545886152ce5ac3feabf619a2