### PR TITLE
fix: support special characters in callgraph

### DIFF
--- a/src/callgraphgenerator.cpp
+++ b/src/callgraphgenerator.cpp
@@ -28,7 +28,7 @@ QHash<Data::Symbol, QString> writeGraph(QTextStream& stream, const Data::Symbol&
     if (symbol.prettySymbol.isEmpty()) {
         stream << "??";
     } else {
-        stream << symbol.prettySymbol;
+        stream << symbol.prettySymbol.toHtmlEscaped();
     }
     stream << "\", color=\"" << settings->callgraphActiveColor().name() << "\"]\n";
 


### PR DESCRIPTION
Some languages put stuff like " in the symbol name which breaks the callgraph. This patch fixes that by using html escape strings.

Fixes: #691