### PR TITLE
Fix crash when attaching to a running process

### DIFF
--- a/src/recordpage.cpp
+++ b/src/recordpage.cpp
@@ -687,7 +687,8 @@ void RecordPage::updateProcessesFinished()
         return;
     }
 
-    m_processModel->mergeProcesses(m_watcher->result());
+    if (!m_watcher->isCanceled())
+        m_processModel->mergeProcesses(m_watcher->result());
     QTimer::singleShot(1000, this, &RecordPage::updateProcesses);
 }
 


### PR DESCRIPTION
If the user clicks the button while the process list is updating, the future is canceled, and calling result() on it is undefined behavior (and crashes). ASAN just says
/usr/include/c++/14/bits/stl_tree.h:359:59: runtime error: member call on null pointer of type 'const struct _Rb_tree_node'