### PR TITLE
fix: escape special symbols in node labels of children, too

### DIFF
--- a/src/callgraphgenerator.cpp
+++ b/src/callgraphgenerator.cpp
@@ -62,7 +62,7 @@ void resultsToDot(int height, Direction direction, const Data::Symbol& symbol, c
     const auto entry = results.entries[symbol];
 
     auto addNode = [&stream](const QString& id, const QString& label) {
-        stream << "node" << id << " [label=\"" << label << "\"]\n";
+        stream << "node" << id << " [label=\"" << label.toHtmlEscaped() << "\"]\n";
     };
     auto connectNodes = [&stream, direction](const QString& parent, const QString& child) {
         if (direction == Direction::Callee) {


### PR DESCRIPTION
## A Warning :)
C++ is not my everyday language, nor am I super familiar with the code to know if this may have unintended consequences.

## Details
Further fixes to #691 continuing the initial fix in fd9f7d10cd00832f2212b36f07da1752cbe550d5

I was able to test this locally with a perf.data file exhibiting the problem in the original issue and have not had problems seeing the graph while browsing various items in the Callee/Caller tab that previously failed.

I wasn't sure if line 88 would have been more appropriate/canonical for this fix...

