### PR TITLE
Properly include kgraphviewer_interface.h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -128,6 +128,10 @@ if(QCustomPlot_FOUND)
     target_link_libraries(hotspot QCustomPlot::QCustomPlot)
 endif()
 
+if(KGraphViewerPart_FOUND)
+    target_link_libraries(hotspot KGraphViewerPart)
+endif()
+
 set_target_properties(hotspot PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${KDE_INSTALL_BINDIR}")
 
 install(

--- a/src/callgraphwidget.cpp
+++ b/src/callgraphwidget.cpp
@@ -24,7 +24,7 @@
 #include "ui_callgraphwidget.h"
 #include "util.h"
 
-#include <kgraphviewer/kgraphviewer_interface.h>
+#include <kgraphviewer_interface.h>
 
 CallgraphWidget::CallgraphWidget(Data::CallerCalleeResults results, KParts::ReadOnlyPart* view,
                                  KGraphViewer::KGraphViewerInterface* interface, QWidget* parent)


### PR DESCRIPTION
The KGraphViewerPart CMake target sets the include-directory for the compiler including the kgraphviewer parent directory. Properly linking against the KGraphViewerPart target and fixing the include path is important when not using a system-wide installation of KGraphViewerPart (or when it is not installed in the default location).