### PR TITLE
fix: Always call QToolTip::showText with a widget

### DIFF
--- a/src/models/timeaxisheaderview.cpp
+++ b/src/models/timeaxisheaderview.cpp
@@ -77,7 +77,7 @@ bool TimeAxisHeaderView::event(QEvent* event)
         for (const auto& tracepoint : std::as_const(m_tracepoints.tracepoints)) {
             if (zoomTime.contains(tracepoint.time)) {
                 if (helpEvent->pos().x() == xForTime((tracepoint.time - m_timeRange.start) * oneNanoSecond)) {
-                    QToolTip::showText(helpEvent->globalPos(), tracepoint.name);
+                    QToolTip::showText(helpEvent->globalPos(), tracepoint.name, this);
                     return true;
                 }
             }

--- a/src/models/timelinedelegate.cpp
+++ b/src/models/timelinedelegate.cpp
@@ -323,22 +323,25 @@ bool TimeLineDelegate::helpEvent(QHelpEvent* event, QAbstractItemView* view, con
             QToolTip::showText(
                 event->globalPos(),
                 tr("time: %1\nlost chunks: %2\nlost events: %3")
-                    .arg(formattedTime, QString::number(found.numLost), QString::number(found.totalLost)));
+                    .arg(formattedTime, QString::number(found.numLost), QString::number(found.totalLost)),
+                view);
         } else if (found.numSamples > 0 && found.type == results.offCpuTimeCostId) {
             QToolTip::showText(event->globalPos(),
                                tr("time: %1\nsched switches: %2\ntotal off-CPU time: %3\nlongest sched switch: %4")
                                    .arg(formattedTime, QString::number(found.numSamples),
-                                        Util::formatTimeString(found.totalCost),
-                                        Util::formatTimeString(found.maxCost)));
+                                        Util::formatTimeString(found.totalCost), Util::formatTimeString(found.maxCost)),
+                               view);
         } else if (found.numSamples > 0) {
             QToolTip::showText(event->globalPos(),
                                tr("time: %1\n%5 samples: %2\ntotal sample cost: %3\nmax sample cost: %4")
                                    .arg(formattedTime, QString::number(found.numSamples),
                                         Util::formatCost(found.totalCost), Util::formatCost(found.maxCost),
-                                        totalCosts.value(found.type).label));
+                                        totalCosts.value(found.type).label),
+                               view);
         } else {
             QToolTip::showText(event->globalPos(),
-                               tr("time: %1 (no %2 samples)").arg(formattedTime, totalCosts.value(m_eventType).label));
+                               tr("time: %1 (no %2 samples)").arg(formattedTime, totalCosts.value(m_eventType).label),
+                               view);
         }
         return true;
     }


### PR DESCRIPTION
Under Wayland, a popup must always have a parent window. Otherwise, the tooltip will show up as proper window with title bar and all and steal focus from the main window, causing the tooltip to just close again immediately.

---

Tooltip shows properly on Wayland now:

![Screenshot_20250402_171910](https://github.com/user-attachments/assets/f1f4f953-3ce2-487e-af16-b68b6fb8a094)
