### PR TITLE
Tracefs location

### DIFF
--- a/src/recordhost.cpp
+++ b/src/recordhost.cpp
@@ -116,10 +116,12 @@ bool privsAlreadyElevated()
         struct stat buf;
         return stat(path, &buf) == 0 && ((buf.st_mode & 07777) & required) == required;
     };
-    static const auto paths = {"/sys/kernel/", "/sys/kernel/tracing"};
-    isElevated = std::all_of(paths.begin(), paths.end(), checkPerms);
 
-    return isElevated;
+    if (checkPerms("/sys/kernel/tracing")) {
+        return true;
+    }
+    // tracing used to be mounted on /sys/kernel/debug/ on older systems
+    return checkPerms("/sys/kernel/debug/tracing");
 }
 
 RecordHost::PerfCapabilities fetchLocalPerfCapabilities(const QString& perfPath)

--- a/src/recordhost.cpp
+++ b/src/recordhost.cpp
@@ -69,7 +69,7 @@ QByteArray perfBuildOptions(const QString& perfPath)
 
 bool canTrace(const QString& path)
 {
-    const QFileInfo info(QLatin1String("/sys/kernel/debug/tracing/") + path);
+    const QFileInfo info(QLatin1String("/sys/kernel/tracing/") + path);
     if (!info.isDir() || !info.isReadable()) {
         return false;
     }
@@ -116,7 +116,7 @@ bool privsAlreadyElevated()
         struct stat buf;
         return stat(path, &buf) == 0 && ((buf.st_mode & 07777) & required) == required;
     };
-    static const auto paths = {"/sys/kernel/debug", "/sys/kernel/debug/tracing"};
+    static const auto paths = {"/sys/kernel/", "/sys/kernel/tracing"};
     isElevated = std::all_of(paths.begin(), paths.end(), checkPerms);
 
     return isElevated;

--- a/src/recordhost.cpp
+++ b/src/recordhost.cpp
@@ -111,13 +111,9 @@ bool privsAlreadyElevated()
         return false;
     }
 
-    auto checkPerms = [](const char* path) {
-        const mode_t required = S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH; // 755
-        struct stat buf;
-        return stat(path, &buf) == 0 && ((buf.st_mode & 07777) & required) == required;
-    };
-
-    return checkPerms("/sys/kernel/tracing");
+    const mode_t required = S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH; // 755
+    struct stat buf;
+    return stat("/sys/kernel/tracing", &buf) == 0 && ((buf.st_mode & 07777) & required) == required;
 }
 
 RecordHost::PerfCapabilities fetchLocalPerfCapabilities(const QString& perfPath)

--- a/src/recordhost.cpp
+++ b/src/recordhost.cpp
@@ -117,11 +117,7 @@ bool privsAlreadyElevated()
         return stat(path, &buf) == 0 && ((buf.st_mode & 07777) & required) == required;
     };
 
-    if (checkPerms("/sys/kernel/tracing")) {
-        return true;
-    }
-    // tracing used to be mounted on /sys/kernel/debug/ on older systems
-    return checkPerms("/sys/kernel/debug/tracing");
+    return checkPerms("/sys/kernel/tracing");
 }
 
 RecordHost::PerfCapabilities fetchLocalPerfCapabilities(const QString& perfPath)

--- a/src/recordpage.ui
+++ b/src/recordpage.ui
@@ -265,7 +265,8 @@
       <item row="2" column="0">
        <widget class="QLabel" name="offCpuLabel">
         <property name="toolTip">
-         <string>Record scheduler switch events. This enables off-CPU profiling to measure sleep times etc. This requires elevated privileges.</string>
+         <string>Record scheduler switch events. This enables off-CPU profiling to measure sleep times etc.
+This requires elevated privileges or both /sys/kernel/tracing to be readable and /proc/sys/kernel/perf_event_paranoid == -1.</string>
         </property>
         <property name="text">
          <string>Off-CPU Profilin&amp;g:</string>
@@ -278,7 +279,8 @@
       <item row="2" column="1">
        <widget class="QCheckBox" name="offCpuCheckBox">
         <property name="toolTip">
-         <string>Record scheduler switch events. This enables off-CPU profiling to measure sleep times etc. This requires elevated privileges.</string>
+         <string>Record scheduler switch events. This enables off-CPU profiling to measure sleep times etc.
+This requires elevated privileges or both /sys/kernel/tracing to be readable and /proc/sys/kernel/perf_event_paranoid == -1.</string>
         </property>
         <property name="text">
          <string/>


### PR DESCRIPTION
Hi,

This PR changes the file system location that is checked for `tracefs`. At [least since linux v4.1](https://www.kernel.org/doc/Documentation/trace/ftrace.txt) the default location has been `/sys/kernel/tracing/` instead of `/sys/kernel/debug/tracing/` (but the latter was kept for compatability).

I also changed the tooltip of the 'off-cpu profiling' checkbox to better reflect the conditions under which it can be checked as I had to go look into the source code.

This was an issue for me when setting up rootless 'off-cpu profiling' (ie not using 'elevate privileges'). Turns out the problem was that `/sys/kernel/debug/tracing/` was not readable on my machine but `/sys/kernel/tracing/` was (via `tracing` group).