### PR TITLE
feat: associate application/x-perf-data and application/x-hotspot wit…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,22 @@ if(NOT APPIMAGE_BUILD)
 endif()
 
 install(
+    FILES com.kdab.hotspot.xml
+    DESTINATION ${KDE_INSTALL_MIMEDIR}
+)
+
+find_package(SharedMimeInfo 1.8)
+set_package_properties(
+    SharedMimeInfo PROPERTIES
+    TYPE OPTIONAL
+    PURPOSE "Associate hotspot "
+)
+
+if(SharedMimeInfo_FOUND)
+    update_xdg_mimetypes(${KDE_INSTALL_MIMEDIR})
+endif()
+
+install(
     FILES com.kdab.hotspot.desktop
     DESTINATION ${KDE_INSTALL_APPDIR}
 )

--- a/com.kdab.hotspot.desktop
+++ b/com.kdab.hotspot.desktop
@@ -9,4 +9,4 @@ Exec=hotspot %f
 Icon=hotspot
 Categories=Development;
 Keywords=performance;perf;
-MimeType=application/x-perf-data;
+MimeType=application/x-perf-data;application/x-hotspot;

--- a/com.kdab.hotspot.xml
+++ b/com.kdab.hotspot.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+  <mime-type type="application/x-hotspot">
+    <glob pattern="*.perfparser"/>
+  </mime-type>
+</mime-info>


### PR DESCRIPTION
…h hotspot

This patch adds a custom mimetype for *.perfparser files called application/x-hotspot and registers hotspot as the default application to open it.

Fixes: #718