### PR TITLE
fix: don't try to use a cross-architecture objdump on the native arch…

### DIFF
--- a/src/resultsdisassemblypage.cpp
+++ b/src/resultsdisassemblypage.cpp
@@ -574,10 +574,18 @@ void ResultsDisassemblyPage::showDisassembly()
             return objdump;
 
         if (m_arch.startsWith(QLatin1String("armv8")) || m_arch.startsWith(QLatin1String("aarch64"))) {
-            return QStringLiteral("aarch64-linux-gnu-objdump");
+            if (auto aarch64Objdump = QStandardPaths::findExecutable(QStringLiteral("aarch64-linux-gnu-objdump"));
+                !aarch64Objdump.isEmpty())
+                return QStringLiteral("aarch64-linux-gnu-objdump");
         }
-        const auto isArm = m_arch.startsWith(QLatin1String("arm"));
-        return isArm ? QStringLiteral("arm-linux-gnueabi-objdump") : QStringLiteral("objdump");
+
+        if (m_arch.startsWith(QLatin1String("arm"))) {
+            if (auto armObjdump = QStandardPaths::findExecutable(QStringLiteral("arm-linux-gnueabi-objdump"));
+                !armObjdump.isEmpty())
+                return QStringLiteral("arm-linux-gnueabi-objdump");
+        }
+
+        return QStringLiteral("objdump");
     };
 
     ui->symbolNotFound->hide();


### PR DESCRIPTION
…itecture

If the host architecture is aarch64, aarch64-linux-gnu-objdump may not exist, which is the case on at least Fedora and NixOS, so disassembly doesn't work by default. Similar logic likely also applies to arm-linux-gnueabi-objdump. Fix the problem by only trying to use the cross-architecture objdump if we are not building for the given architecture.