### PR TITLE
fix: install test binaries to correct paths

### DIFF
--- a/tests/modeltests/CMakeLists.txt
+++ b/tests/modeltests/CMakeLists.txt
@@ -5,6 +5,10 @@ add_library(
     disassembly/fib.cpp
 )
 
+set_target_properties(
+    fib PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${KDE_INSTALL_EXECROOTDIR}/tests/modeltests"
+)
+
 ecm_add_test(
     tst_models.cpp
     LINK_LIBRARIES

--- a/tests/test-clients/cpp-recursion/CMakeLists.txt
+++ b/tests/test-clients/cpp-recursion/CMakeLists.txt
@@ -2,3 +2,7 @@ add_executable(
     cpp-recursion
     main.cpp
 )
+
+set_target_properties(
+    cpp-recursion PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${KDE_INSTALL_EXECROOTDIR}/tests/test-clients/cpp-recursion"
+)


### PR DESCRIPTION
With a non-default KDE_INSTALL_EXECROOTDIR (e.g. when building with Nix) the tests are unable to find these binaries, so install them in the correct location.