### PR TITLE
fix: Fix bug in disassembly view tooltip

### DIFF
--- a/src/models/disassemblymodel.cpp
+++ b/src/models/disassemblymodel.cpp
@@ -130,14 +130,15 @@ QVariant DisassemblyModel::data(const QModelIndex& index, int role) const
             return {};
         }
 
+        const auto tooltip = tr("addr: <tt>%1</tt><br/>assembly: <tt>%2</tt><br/>hexdump: <tt>%3</tt>")
+                                 .arg(QString::number(data.addr, 16), line.toHtmlEscaped(), data.hexdump);
+
         auto it = m_offsetMap.find(data.addr);
         if (it != m_offsetMap.end()) {
             const auto event = index.column() - COLUMN_COUNT;
             const auto& locationCost = it.value();
 
             if (role == Qt::ToolTipRole) {
-                auto tooltip = tr("addr: <tt>%1</tt><br/>assembly: <tt>%2</tt><br/>hexdump: <tt>%3</tt>")
-                                   .arg(QString::number(data.addr, 16), line.toHtmlEscaped(), data.hexdump);
                 return Util::formatTooltip(tooltip, locationCost, m_results.selfCosts);
             }
 
@@ -156,7 +157,7 @@ QVariant DisassemblyModel::data(const QModelIndex& index, int role) const
             return Util::formatCostRelative(costLine, totalCost, true);
         } else {
             if (role == Qt::ToolTipRole) {
-                return tr("<qt><tt>%1</tt><hr/>No samples at this location.</qt>").arg(line.toHtmlEscaped());
+                return tr("<qt>%1<hr/>No samples at this location.</qt>").arg(tooltip);
             } else
                 return QString();
         }


### PR DESCRIPTION
The `%3` wasn't provided an argument when it was added in de6f3f823113f742b24ea4cd7465cd60572ca7c6 so it shows up as `%3` in tooltip. I assume that it was meant to be the `hexdump` so I've added that, and made the tooltips consistent by always showing the address, hexdump, and disassembly comments.

| | No samples | With samples |
| --- | --- | --- |
| Before | <img width="218" height="78" alt="image" src="https://github.com/user-attachments/assets/f9196813-b863-4fcd-b6d5-2968f510c0fa" /> | <img width="286" height="156" alt="image" src="https://github.com/user-attachments/assets/fd26f7dc-cac7-43f1-a54f-64f10b95c136" /> |
| After | <img width="282" height="117" alt="image" src="https://github.com/user-attachments/assets/a8c71c7d-bc9e-4d9e-9355-e56e3e85397c" /> | <img width="287" height="170" alt="image" src="https://github.com/user-attachments/assets/0569173a-0663-492e-9ece-240f2736db48" /> |