### PR TITLE
fix: ppc64el test failures in tst_disassemblyoutput

### DIFF
--- a/tests/modeltests/tst_disassemblyoutput.cpp
+++ b/tests/modeltests/tst_disassemblyoutput.cpp
@@ -263,11 +263,12 @@ private slots:
         };
 
         for (const auto& line : result.disassemblyLines) {
-            QVERIFY(!line.branchVisualisation.isEmpty());
-
-            // check that we only captures valid visualisation characters
-            QVERIFY(std::all_of(line.branchVisualisation.cbegin(), line.branchVisualisation.cend(),
-                                isValidVisualisationCharacter));
+            // not every architecture emits branch visualisation for every line (e.g. ppc64el)
+            if (!line.branchVisualisation.isEmpty()) {
+                // check that we only capture valid visualisation characters
+                QVERIFY(std::all_of(line.branchVisualisation.cbegin(), line.branchVisualisation.cend(),
+                                    isValidVisualisationCharacter));
+            }
 
             QVERIFY(std::all_of(line.hexdump.cbegin(), line.hexdump.cend(), isValidHexdumpCharacter));
 
@@ -392,8 +393,7 @@ private:
     };
     static FunctionData findAddressAndSizeOfFunc(const QString& library, const QString& name)
     {
-        QRegularExpression regex(QStringLiteral("[ ]+[0-9]+: ([0-9a-f]+)[ ]+([0-9]+)[0-9 a-zA-Z]+%1\\n").arg(name));
-
+        QRegularExpression regex(QStringLiteral("[ ]+[0-9]+: ([0-9a-f]+)[ ]+([0-9]+)[^\\n]+%1").arg(name));
         const auto readelfBinary = QStandardPaths::findExecutable(QStringLiteral("readelf"));
         VERIFY_OR_THROW(!readelfBinary.isEmpty());
 


### PR DESCRIPTION
Fixes two test failures on ppc64el in tst_disassemblyoutput:

1. **readelf regex**: Character class [0-9 a-zA-Z]+ too restrictive for ppc64el readelf -s output. Changed to [^\n]+ which matches any format while stopping at newline.

2. **Branch visualisation**: Not every architecture emits branch visualisation for every disassembly line. Wrapped QVERIFY with isEmpty() check.

Both fixes from the Debian PowerPC porter analysis in https://bugs.debian.org/1129621#17

Run on a real IBM POWER8 S824 (ppc64le), not emulated, where `tst_disassemblyoutput`
reproduced both failures before the change and passed after it. The regex change is
backwards-compatible: `[^\n]+` accepts everything the old `[0-9 a-zA-Z]+` accepted.

I have not re-run it since; that machine is powered down at the moment.

Fixes #766