### PR TITLE
startpage: Make loading results error label selectable by mouse

### DIFF
--- a/src/startpage.ui
+++ b/src/startpage.ui
@@ -161,6 +161,9 @@
          <property name="alignment">
           <set>Qt::AlignCenter</set>
          </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         </property>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
Allows to copy an error text to e.g. search for it.