### PR TITLE
tests: fix ppc64el test failures in tst_disassemblyoutput

### DIFF
--- a/tests/modeltests/tst_disassemblyoutput.cpp
+++ b/tests/modeltests/tst_disassemblyoutput.cpp
@@ -266,11 +266,12 @@ private slots:
         };
 
         for (const auto& line : result.disassemblyLines) {
-            QVERIFY(!line.branchVisualisation.isEmpty());
-
-            // check that we only captures valid visualisation characters
-            QVERIFY(std::all_of(line.branchVisualisation.cbegin(), line.branchVisualisation.cend(),
-                                isValidVisualisationCharacter));
+            // not every architecture emits branch visualisation for every line
+            if (!line.branchVisualisation.isEmpty()) {
+                // check that we only capture valid visualisation characters
+                QVERIFY(std::all_of(line.branchVisualisation.cbegin(), line.branchVisualisation.cend(),
+                                    isValidVisualisationCharacter));
+            }
 
             QVERIFY(std::all_of(line.hexdump.cbegin(), line.hexdump.cend(), isValidHexdumpCharacter));
 
@@ -395,7 +396,7 @@ private:
     };
     static FunctionData findAddressAndSizeOfFunc(const QString& library, const QString& name)
     {
-        QRegularExpression regex(QStringLiteral("[ ]+[0-9]+: ([0-9a-f]+)[ ]+([0-9]+)[0-9 a-zA-Z]+%1\\n").arg(name));
+        QRegularExpression regex(QStringLiteral("[ ]+[0-9]+: ([0-9a-f]+)[ ]+([0-9]+)[^\\n]+%1\\n").arg(name));
 
         const auto readelfBinary = QStandardPaths::findExecutable(QStringLiteral("readelf"));
         VERIFY_OR_THROW(!readelfBinary.isEmpty());


### PR DESCRIPTION
## Summary
- Fix test failures on ppc64el in `testDetectBranches` by relaxing regex matching and handling missing branch visualisation

## Changes
| File | Change |
|------|--------|
| `tests/modeltests/tst_disassemblyoutput.cpp` | Relax readelf regex from `[0-9 a-zA-Z]+` to `[^\\n]+`; wrap branch visualisation check in `isEmpty()` guard |

## Context
On ppc64el, the readelf output format differs from x86_64 in the symbol table, causing the regex to fail. Additionally, not every disassembly line on ppc64el contains branch visualisation output.

Patch source: Debian powerpc porter analysis (see [Debian #1129621](https://bugs.debian.org/1129621#17))

## Test Plan
- [x] Changes are limited to test code only
- [x] Regex relaxation is more permissive without changing capture groups
- [ ] CI verification on ppc64el (cannot test locally)

Fixes #766
